### PR TITLE
시뮬레이터에서 카메라 버튼 누르면 크래시 나는 현상 수정

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -505,6 +505,11 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
     public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard var asset = self.focusedCollection?.assets[indexPath.row] else { return }
         if asset.camera {
+            if TARGET_OS_SIMULATOR != 0 {
+                print("not supported by the simulator.")
+                return
+            }
+
             showCamera()
             return
         }


### PR DESCRIPTION
시뮬레이터로 돌렸을 때, 컬렉션뷰 첫번째에 있는 카메라 셀을 터치하면 크래시가 발생합니다.
그 대신 로그를 찍도록 변경해봤습니다.