### PR TITLE
:bug: carsh on iPhone 5 when taking pictures with the camera

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -433,7 +433,9 @@ extension TLPhotosPickerViewController: UIImagePickerControllerDelegate, UINavig
                     var result = TLPHAsset(asset: asset)
                     result.selectedOrder = self.selectedAssets.count + 1
                     self.selectedAssets.append(result)
-                    self.dismiss(done: true)
+					DispatchQueue.main.async {
+						self.dismiss(done: true)
+					}
                 }
             })
         }


### PR DESCRIPTION

IPhone 5 When iOS 10.3.1 uses the camera to take pictures
The app crashes because the dismiss method is not running on the main thread.

/*
아이폰5 iOS 10.3.1에서 카메라를 사용하여 사진을 찍어 사용하는 경우 
dismiss 메소드가 메인쓰레드에서 실행되지 않아 앱이 크래쉬 됩니다. 
*/
