### PR TITLE
Enforce Swift 4 usage in the podspec.

### DIFF
--- a/TLPhotoPicker.podspec
+++ b/TLPhotoPicker.podspec
@@ -29,6 +29,7 @@ TODO: Add long description of the pod here.
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '9.1'
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
 
   s.source_files = 'TLPhotoPicker/Classes/**/*'
   


### PR DESCRIPTION
This will still work if the other apps are building with Swift 3.2, since those versions can co-exist between projects.