### PR TITLE
Support a custom collection of TLPHAssets

### DIFF
--- a/TLPhotoPicker.podspec
+++ b/TLPhotoPicker.podspec
@@ -39,4 +39,5 @@ TODO: Add long description of the pod here.
   # s.public_header_files = 'Pod/Classes/**/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
   # s.dependency 'AFNetworking', '~> 2.3'
+  s.dependency 'SDWebImage'
 end

--- a/TLPhotoPicker/Classes/TLAssetsCollection.swift
+++ b/TLPhotoPicker/Classes/TLAssetsCollection.swift
@@ -12,6 +12,7 @@ import PhotosUI
 import MobileCoreServices
 
 public class TLPHAsset {
+    
     enum CloudDownloadState {
         case ready, progress, complete, failed
     }
@@ -32,9 +33,9 @@ public class TLPHAsset {
             guard let phAsset = self.phAsset else { return .photo }
             if phAsset.mediaSubtypes.contains(.photoLive) {
                 return .livePhoto
-            }else if phAsset.mediaType == .video {
+            } else if phAsset.mediaType == .video {
                 return .video
-            }else {
+            } else {
                 return .photo
             }
         }
@@ -46,13 +47,15 @@ public class TLPHAsset {
             _fullResolutionImage = newValue
         }
         get {
-            if let _ = _fullResolutionImage {
-                return _fullResolutionImage
+            if let image = _fullResolutionImage {
+                return image
             }
             guard let phAsset = self.phAsset else { return nil }
             return TLPhotoLibrary.fullResolutionImageData(asset: phAsset)
         }
     }
+    
+    public var url: URL?
     
     public func extType() -> ImageExtType {
         var ext = ImageExtType.png
@@ -208,6 +211,11 @@ public class TLPHAsset {
     public convenience init(image: UIImage) {
         self.init(asset: nil)
         self.fullResolutionImage = image
+    }
+    
+    public convenience init(url: URL) {
+        self.init(asset: nil)
+        self.url = url
     }
 }
 

--- a/TLPhotoPicker/Classes/TLAssetsCollection.swift
+++ b/TLPhotoPicker/Classes/TLAssetsCollection.swift
@@ -265,7 +265,7 @@ public struct TLAssetsCollection {
     func getTLAsset(at index: Int) -> TLPHAsset? {
         if self.useCameraButton && index == 0 { return nil }
         let index = index - (self.useCameraButton ? 1 : 0)
-        if let assets = self.customAssets {
+        if let assets = self.customAssets, index < assets.count {
             return assets[index]
         } else {
             guard let result = self.fetchResult, index < result.count else { return nil }

--- a/TLPhotoPicker/Classes/TLBundle.swift
+++ b/TLPhotoPicker/Classes/TLBundle.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 class TLBundle {
+    
     class func podBundleImage(named: String) -> UIImage? {
         let podBundle = Bundle(for: TLBundle.self)
         if let url = podBundle.url(forResource: "TLPhotoPickerController", withExtension: "bundle") {

--- a/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
+++ b/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
@@ -145,6 +145,7 @@ open class TLPhotoCollectionViewCell: UICollectionViewCell {
         super.awakeFromNib()
         self.playerView?.playerLayer.videoGravity = AVLayerVideoGravity.resizeAspectFill
         self.livePhotoView?.isHidden = true
+        self.durationLabel?.isHidden = true
         self.durationView?.isHidden = true
         self.selectedView?.isHidden = true
         self.selectedView?.layer.borderWidth = 10
@@ -156,6 +157,7 @@ open class TLPhotoCollectionViewCell: UICollectionViewCell {
     override open func prepareForReuse() {
         super.prepareForReuse()
         self.livePhotoView?.isHidden = true
+        self.durationLabel?.isHidden = true
         self.durationView?.isHidden = true
         self.durationView?.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.6)
         self.selectedHeight?.constant = 10

--- a/TLPhotoPicker/Classes/TLPhotoLibrary.swift
+++ b/TLPhotoPicker/Classes/TLPhotoLibrary.swift
@@ -148,10 +148,10 @@ extension TLPhotoLibrary {
             let fetchCollection = PHAssetCollection.fetchAssetCollections(with: .album, subtype: subType, options: nil)
             var collections = [PHAssetCollection]()
             fetchCollection.enumerateObjects { (collection, index, _) in
-                //Why this? : Can't getting image for cloud shared album
-                if collection.assetCollectionSubtype != .albumCloudShared {
+//                //Why this? : Can't getting image for cloud shared album
+//                if collection.assetCollectionSubtype != .albumCloudShared {
                     collections.append(collection)
-                }
+//                }
             }
             for collection in collections {
                 if !result.contains(where: { $0.localIdentifier == collection.localIdentifier }) {

--- a/TLPhotoPicker/Classes/TLPhotoLibrary.swift
+++ b/TLPhotoPicker/Classes/TLPhotoLibrary.swift
@@ -12,7 +12,7 @@ import Photos
 protocol TLPhotoLibraryDelegate: class {
     func loadCameraRollCollection(collection: TLAssetsCollection)
     func loadCompleteAllCollection(collections: [TLAssetsCollection])
-    func focusCollection(collection: TLAssetsCollection)
+    func focusCollection(collection: TLAssetsCollection?)
 }
 
 class TLPhotoLibrary {
@@ -194,7 +194,6 @@ extension TLPhotoLibrary {
                 cameraRoll.useCameraButton = useCameraButton
                 assetCollections[0] = cameraRoll
                 DispatchQueue.main.async {
-                    self?.delegate?.focusCollection(collection: cameraRoll)
                     self?.delegate?.loadCameraRollCollection(collection: cameraRoll)
                 }
             }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -11,6 +11,7 @@ import Photos
 import PhotosUI
 import MobileCoreServices
 import UIKit.UIGestureRecognizerSubclass
+import SDWebImage
 
 public protocol TLPhotosPickerViewControllerDelegate: class {
     func willDismissPhotoPicker(with phAssets: [PHAsset])
@@ -810,8 +811,17 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
         } else {
             cell.indicator?.stopAnimating()
         }
-        if let customCollection = customCollection, collection == customCollection, let image = asset.fullResolutionImage {
-            cell.imageView?.image = image
+        if let customCollection = customCollection, collection == customCollection {
+            if let image = asset.fullResolutionImage {
+                cell.imageView?.image = image
+            } else if let url = asset.url {
+                cell.imageView?.sd_setImage(with: url,
+                                            placeholderImage: self.configure.placeholderIcon,
+                                            options: [.continueInBackground, .allowInvalidSSLCertificates, .highPriority],
+                                            completed: { (image, error, type, url) -> Void in
+                                                asset.fullResolutionImage = image
+                })
+            }
         } else if let phAsset = asset.phAsset {
             if self.usedPrefetch {
                 let options = PHImageRequestOptions()

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -46,6 +46,7 @@ public struct TLPhotosPickerConfigure {
     public var muteAudio = true
     public var mediaType: PHAssetMediaType? = nil
     public var numberOfColumn = 3
+    public var itemMinSpacing: CGFloat = 5
     public var singleSelectedMode = false
     public var maxSelectedAssets: Int? = nil
     public var isSwipeSelectionEnabled: Bool = true
@@ -230,8 +231,10 @@ extension TLPhotosPickerViewController {
     
     fileprivate func initItemSize() {
         guard let layout = self.collectionView.collectionViewLayout as? UICollectionViewFlowLayout else { return }
+        layout.minimumLineSpacing = self.configure.itemMinSpacing
+        layout.minimumInteritemSpacing = self.configure.itemMinSpacing
         let count = CGFloat(self.configure.numberOfColumn)
-        let width = (self.view.frame.size.width-(5*(count-1)))/count
+        let width = (self.view.frame.size.width-(self.configure.itemMinSpacing*(count-1)))/count
         self.thumbnailSize = CGSize(width: width, height: width)
         layout.itemSize = self.thumbnailSize
         self.collectionView.collectionViewLayout = layout
@@ -1014,9 +1017,5 @@ extension TLPhotosPickerViewController: UIGestureRecognizerDelegate {
                 self.deselectIndexPath(IndexPath(row: i, section: 0), asset: asset)
             }
         }
-    }
-    
-    fileprivate func applySwipeSelections() {
-        
     }
 }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -830,6 +830,10 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
                 let requestId = self.photoLibrary.imageAsset(asset: phAsset, size: self.thumbnailSize, options: options) { [weak cell] (image,complete) in
                     DispatchQueue.main.async {
                         if self.requestIds[indexPath] != nil {
+                            if let currentCell = collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell,
+                                currentCell != cell {
+                                cell = currentCell
+                            }
                             cell?.imageView?.image = image
                             if complete {
                                 self.requestIds.removeValue(forKey: indexPath)
@@ -846,6 +850,10 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
                     let requestId = self.photoLibrary.imageAsset(asset: phAsset, size: self.thumbnailSize, completionBlock: { (image,complete) in
                         DispatchQueue.main.async {
                             if self.requestIds[indexPath] != nil {
+                                if let currentCell = collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell,
+                                   currentCell != cell {
+                                    cell = currentCell
+                                }
                                 cell?.imageView?.image = image
                                 if self.allowedVideo {
                                     cell?.durationView?.isHidden = asset.type != .video
@@ -935,7 +943,7 @@ extension TLPhotosPickerViewController: UITableViewDelegate,UITableViewDataSourc
     }
     
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "TLCollectionTableViewCell", for: indexPath) as! TLCollectionTableViewCell
+        var cell = tableView.dequeueReusableCell(withIdentifier: "TLCollectionTableViewCell", for: indexPath) as! TLCollectionTableViewCell
         let collection = self.collections[indexPath.row]
         cell.thumbImageView.image = collection.thumbnail
         cell.titleLabel.text = collection.title
@@ -945,6 +953,10 @@ extension TLPhotosPickerViewController: UITableViewDelegate,UITableViewDataSourc
             let size = CGSize(width: 80*scale, height: 80*scale)
             self.photoLibrary.imageAsset(asset: phAsset, size: size, completionBlock: { [weak cell] (image,complete) in
                 DispatchQueue.main.async {
+                    if let currentCell = tableView.cellForRow(at: indexPath) as? TLCollectionTableViewCell,
+                        currentCell != cell {
+                        cell = currentCell
+                    }
                     cell?.thumbImageView.image = image
                 }
             })

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.xib
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.xib
@@ -97,7 +97,7 @@
                         </navigationItem>
                     </items>
                 </navigationBar>
-                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="4gR-Bn-quP">
+                <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="4gR-Bn-quP">
                     <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="5" minimumInteritemSpacing="5" id="VDa-Pp-VBq">

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.xib
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.xib
@@ -16,6 +16,7 @@
                 <outlet property="cancelButton" destination="sqJ-Z7-zxj" id="J6u-hz-ePK"/>
                 <outlet property="collectionView" destination="4gR-Bn-quP" id="ZOF-qU-cpd"/>
                 <outlet property="customNavItem" destination="5CU-MZ-p1K" id="ih7-d3-nco"/>
+                <outlet property="customNavigationBar" destination="X8O-Gg-slz" id="Qrr-gF-XGH"/>
                 <outlet property="doneButton" destination="daA-Ag-vVv" id="P53-fy-Sbh"/>
                 <outlet property="emptyImageView" destination="YDZ-o1-AXT" id="TVN-0v-aQc"/>
                 <outlet property="emptyMessageLabel" destination="7qj-q4-rHC" id="Bcp-Hu-lEY"/>


### PR DESCRIPTION
It may be not what you want, and I broke the APIs of TLPhotosPickerViewControllerDelegate. 
Here's a brief list of changes in the commit of [eef1c6c](https://github.com/tilltue/TLPhotoPicker/pull/68/commits/eef1c6cba2435dda3305b36d6da175178a627552):
- Support a custom collection of TLPHAssets which doesn't belong to the photo library.
- Choose the custom collection by default if it's available.
- Changed TLPHAsset from struct to class to become reference type.
- Added localIdentifier to TLPHAsset for direct comparing.
- Updated TLPhotosPickerViewControllerDelegate for complex callbacks.
- Set picker's navigationBar.isTranslucent to false by default.