### PR TITLE
Add new swift_version parameter to podspec

### DIFF
--- a/TLPhotoPicker.podspec
+++ b/TLPhotoPicker.podspec
@@ -29,6 +29,7 @@ TODO: Add long description of the pod here.
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '9.1'
+  s.swift_version = '4.0'
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
 
   s.source_files = 'TLPhotoPicker/Classes/**/*'


### PR DESCRIPTION
Cocoapods 1.4.0 adds support for setting the Swift version used by a pod. This should fix the problems with the SWIFT_VERSION field not actually being applied when building.