### PR TITLE
Add support for delegate/block-based handling of no camera permissions

### DIFF
--- a/Example/TLPhotoPicker/ViewController.swift
+++ b/Example/TLPhotoPicker/ViewController.swift
@@ -20,7 +20,7 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
         let viewController = CustomPhotoPickerViewController()
         viewController.delegate = self
         viewController.didExceedMaximumNumberOfSelection = { [weak self] (picker) in
-            self?.showAlert(vc: picker)
+            self?.showExceededMaximumAlert(vc: picker)
         }
         var configure = TLPhotosPickerConfigure()
         configure.numberOfColumn = 3
@@ -34,7 +34,7 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
         let viewController = CustomPhotoPickerViewController()
         viewController.delegate = self
         viewController.didExceedMaximumNumberOfSelection = { [weak self] (picker) in
-            self?.showAlert(vc: picker)
+            self?.showExceededMaximumAlert(vc: picker)
         }
         var configure = TLPhotosPickerConfigure()
         configure.numberOfColumn = 3
@@ -50,7 +50,7 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
         let viewController = PhotoPickerWithNavigationViewController()
         viewController.delegate = self
         viewController.didExceedMaximumNumberOfSelection = { [weak self] (picker) in
-            self?.showAlert(vc: picker)
+            self?.showExceededMaximumAlert(vc: picker)
         }
         var configure = TLPhotosPickerConfigure()
         configure.numberOfColumn = 3
@@ -122,10 +122,16 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
     }
 
     func didExceedMaximumNumberOfSelection(picker: TLPhotosPickerViewController) {
-        self.showAlert(vc: picker)
+        self.showExceededMaximumAlert(vc: picker)
+    }
+    
+    func handleNoCameraPermissions(picker: TLPhotosPickerViewController) {
+        let alert = UIAlertController(title: "", message: "No camera permissions granted", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
+        self.present(alert, animated: true, completion: nil)
     }
 
-    func showAlert(vc: UIViewController) {
+    func showExceededMaximumAlert(vc: UIViewController) {
         let alert = UIAlertController(title: "", message: "Exceed Maximum Number Of Selection", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
         vc.present(alert, animated: true, completion: nil)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
     func didExceedMaximumNumberOfSelection(picker: TLPhotosPickerViewController) {
         // exceed max selection
     }
+    func handleNoCameraPermissions(picker: TLPhotosPickerViewController) {
+        // Handle no camera permissions case
+    }
 }
 
 //Custom Cell must subclass TLPhotoCollectionViewCell
@@ -106,6 +109,7 @@ class CustomCell_Instagram: TLPhotoCollectionViewCell {
     convenience public init(withPHAssets: (([PHAsset]) -> Void)? = nil, didCancel: ((Void) -> Void)? = nil)
     convenience public init(withTLPHAssets: (([TLPHAsset]) -> Void)? = nil, didCancel: ((Void) -> Void)? = nil)
     open var didExceedMaximumNumberOfSelection: ((TLPhotosPickerViewController) -> Void)? = nil
+    open var handleNoCameraPermissions: ((TLPhotosPickerViewController) -> Void)? = nil
     open var dismissCompletion: (() -> Void)? = nil
 ```
 ```swift
@@ -117,6 +121,9 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
         }, didCancel: nil)
         viewController.didExceedMaximumNumberOfSelection = { [weak self] (picker) in
             //exceed max selection
+        }
+        viewController.handleNoCameraPermissions = { [weak self] (picker) in
+            // handle no camera permissions case
         }
         viewController.selectedAssets = self.selectedAssets
         self.present(viewController, animated: true, completion: nil)

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -17,6 +17,7 @@ public protocol TLPhotosPickerViewControllerDelegate: class {
     func dismissComplete()
     func photoPickerDidCancel()
     func didExceedMaximumNumberOfSelection(picker: TLPhotosPickerViewController)
+    func handleNoCameraPermissions(picker: TLPhotosPickerViewController)
 }
 extension TLPhotosPickerViewControllerDelegate {
     public func dismissPhotoPicker(withPHAssets: [PHAsset]) { }
@@ -117,6 +118,7 @@ open class TLPhotosPickerViewController: UIViewController {
         }
     }
     @objc open var didExceedMaximumNumberOfSelection: ((TLPhotosPickerViewController) -> Void)? = nil
+    @objc open var handleNoCameraPermissions: ((TLPhotosPickerViewController) -> Void)? = nil
     @objc open var dismissCompletion: (() -> Void)? = nil
     fileprivate var completionWithPHAssets: (([PHAsset]) -> Void)? = nil
     fileprivate var completionWithTLPHAssets: (([TLPHAsset]) -> Void)? = nil
@@ -450,6 +452,26 @@ extension TLPhotosPickerViewController: TLPhotoLibraryDelegate {
 
 // MARK: - Camera Picker
 extension TLPhotosPickerViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    fileprivate func showCameraIfAuthorized() {
+        let cameraAuthorization = AVCaptureDevice.authorizationStatus(for: .video)
+        switch cameraAuthorization {
+        case .authorized:
+            self.showCamera()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video, completionHandler: { [weak self] (authorized) in
+                DispatchQueue.main.async { [weak self] in
+                    if authorized {
+                        self?.showCamera()
+                    } else {
+                        self?.handleNoCameraAuthorization()
+                    }
+                }
+            })
+        case .restricted, .denied:
+            self.handleNoCameraAuthorization()
+        }
+    }
+
     fileprivate func showCamera() {
         guard !maxCheck() else { return }
         let picker = UIImagePickerController()
@@ -464,6 +486,11 @@ extension TLPhotosPickerViewController: UIImagePickerControllerDelegate, UINavig
         picker.allowsEditing = false
         picker.delegate = self
         self.present(picker, animated: true, completion: nil)
+    }
+
+    fileprivate func handleNoCameraAuthorization() {
+        self.delegate?.handleNoCameraPermissions(picker: self)
+        self.handleNoCameraPermissions?(self)
     }
     
     open func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
@@ -649,7 +676,7 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
                 if let nibName = self.configure.cameraCellNibSet?.nibName {
                     cell.selectedCell()
                 }else {
-                    showCamera()
+                    showCameraIfAuthorized()
                 }
                 return
             }


### PR DESCRIPTION
I wasn't 100% sure of the best name for the delegate/block, but the feature works as expected and allows the implementing app to perform some handling (such as showing an alert) of the cases where camera permissions have been denied.