### PR TITLE
Fix video max duration selection

### DIFF
--- a/TLPhotoPicker/Classes/TLBundle.swift
+++ b/TLPhotoPicker/Classes/TLBundle.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 class TLBundle {
     class func podBundleImage(named: String) -> UIImage? {


### PR DESCRIPTION
Two bug fixes when _**maxVideoDuration**_ option is set. 

When you set the maxVideoDuration, like 30 seconds, it works on initial loading. But if you change album and go back to the camera roll, you can see the videos that are longer than 30 seconds. 

Also, the number of media of the album does not match with the exact number of media when maxVideoDuration is set.