### PR TITLE
Fixed predicate inconsistency problem when maxVideoDuration is set

### DIFF
--- a/TLPhotoPicker/Classes/TLBundle.swift
+++ b/TLPhotoPicker/Classes/TLBundle.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 class TLBundle {
     class func podBundleImage(named: String) -> UIImage? {

--- a/TLPhotoPicker/Classes/TLPhotoLibrary.swift
+++ b/TLPhotoPicker/Classes/TLPhotoLibrary.swift
@@ -17,6 +17,7 @@ protocol TLPhotoLibraryDelegate: class {
 
 class TLPhotoLibrary {
     
+    var configure: TLPhotosPickerConfigure?
     weak var delegate: TLPhotoLibraryDelegate? = nil
     
     lazy var imageManager: PHCachingImageManager = {
@@ -127,16 +128,42 @@ extension TLPhotoLibrary {
         return options
     }
     
+    func predicate(for collection: TLAssetsCollection?) -> NSPredicate? {
+        guard let phAssetCollection = collection?.phAssetCollection else { return nil }
+        guard let configure = configure else {return nil}
+        
+        var predicate: NSPredicate?
+        
+        if let duration = configure.maxVideoDuration, phAssetCollection.assetCollectionSubtype == .smartAlbumVideos {
+            predicate = NSPredicate(format: "mediaType = %i AND duration <= %f", PHAssetMediaType.video.rawValue, duration)
+        } else {
+            if let mediaType = configure.mediaType {
+                predicate = configure.maxVideoDuration != nil && mediaType == PHAssetMediaType.video ? NSPredicate(format: "mediaType = %i AND duration < %f", mediaType.rawValue, configure.maxVideoDuration! + 1) : NSPredicate(format: "mediaType = %i", mediaType.rawValue)
+            } else if !configure.allowedVideo {
+                predicate = NSPredicate(format: "mediaType = %i", PHAssetMediaType.image.rawValue)
+            } else if let duration = configure.maxVideoDuration {
+                predicate = NSPredicate(format: "mediaType = %i OR (mediaType = %i AND duration < %f)", PHAssetMediaType.image.rawValue, PHAssetMediaType.video.rawValue, duration + 1)
+            }
+        }
+        
+        return predicate
+    }
+    
     func fetchResult(collection: TLAssetsCollection?, maxVideoDuration:TimeInterval?=nil, options: PHFetchOptions? = nil) -> PHFetchResult<PHAsset>? {
         guard let phAssetCollection = collection?.phAssetCollection else { return nil }
         let options = options ?? getOption()
-        if let duration = maxVideoDuration, phAssetCollection.assetCollectionSubtype == .smartAlbumVideos {
-            options.predicate = NSPredicate(format: "mediaType = %i AND duration < %f", PHAssetMediaType.video.rawValue, duration + 1)
+        
+        if let predicate = predicate(for: collection) {
+            options.predicate = predicate
+            return PHAsset.fetchAssets(in: phAssetCollection, options: options)
+        } else {
+            return nil
         }
-        return PHAsset.fetchAssets(in: phAssetCollection, options: options)
     }
     
     func fetchCollection(configure: TLPhotosPickerConfigure) {
+        self.configure = configure
+        
         let allowedVideo = configure.allowedVideo
         let useCameraButton = configure.usedCameraButton
         let mediaType = configure.mediaType
@@ -169,6 +196,7 @@ extension TLPhotoLibrary {
             let fetchCollection = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: subType, options: nil)
             if let collection = fetchCollection.firstObject, !result.contains(where: { $0.localIdentifier == collection.localIdentifier }) {
                 var assetsCollection = TLAssetsCollection(collection: collection)
+                options.predicate = self.predicate(for: assetsCollection)
                 assetsCollection.fetchResult = PHAsset.fetchAssets(in: collection, options: options)
                 if assetsCollection.count > 0 || useCameraButton {
                     result.append(assetsCollection)
@@ -177,15 +205,7 @@ extension TLPhotoLibrary {
             }
             return nil
         }
-        
-        if let mediaType = mediaType {
-            options.predicate = maxVideoDuration != nil && mediaType == PHAssetMediaType.video ? NSPredicate(format: "mediaType = %i AND duration < %f", mediaType.rawValue, maxVideoDuration! + 1) : NSPredicate(format: "mediaType = %i", mediaType.rawValue)
-        } else if !allowedVideo {
-            options.predicate = NSPredicate(format: "mediaType = %i", PHAssetMediaType.image.rawValue)
-        } else if let duration = maxVideoDuration {
-            options.predicate = NSPredicate(format: "mediaType = %i OR (mediaType = %i AND duration < %f)", PHAssetMediaType.image.rawValue, PHAssetMediaType.video.rawValue, duration + 1)
-        }
-        
+                
         DispatchQueue.global(qos: .userInteractive).async { [weak self] in
             var assetCollections = [TLAssetsCollection]()
             //Camera Roll
@@ -215,6 +235,7 @@ extension TLPhotoLibrary {
             albumsResult.enumerateObjects({ (collection, index, stop) -> Void in
                 guard let collection = collection as? PHAssetCollection else { return }
                 var assetsCollection = TLAssetsCollection(collection: collection)
+                options.predicate = self?.predicate(for: assetsCollection)
                 assetsCollection.fetchResult = PHAsset.fetchAssets(in: collection, options: options)
                 if assetsCollection.count > 0, !assetCollections.contains(where: { $0.localIdentifier == collection.localIdentifier }) {
                     assetCollections.append(assetsCollection)


### PR DESCRIPTION
When you set the maxVideoDuration, like 30 seconds, it works on initial loading. But if you change album and go back to the camera roll, you can see the videos that are longer than 30 seconds.

Also, the number of media on the album does not match with the exact number of media when maxVideoDuration is set.