### PR TITLE
on #96. To unify handling of no album authorization.

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -183,7 +183,6 @@ open class TLPhotosPickerViewController: UIViewController {
                 case .authorized:
                     self?.initPhotoLibrary()
                 default:
-                    self?.dismiss(done: false)
                     self?.handleDeniedAlbumsAuthorization()
                 }
             }


### PR DESCRIPTION
When denied the controller dismisses and if originally denied there's no dismiss line. So it's tricky to dimiss the view controller in the handleNoAlbumAuthorization delegate method.
And it's possible for user to customize the PhotosPickerViewController to show some other views without dismissing on default case.