### PR TITLE
added delegate functions to collect logs of user events

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -19,6 +19,12 @@ public protocol TLPhotosPickerViewControllerDelegate: class {
     func didExceedMaximumNumberOfSelection(picker: TLPhotosPickerViewController)
     func handleNoAlbumPermissions(picker: TLPhotosPickerViewController)
     func handleNoCameraPermissions(picker: TLPhotosPickerViewController)
+    
+    //for log
+    func selectedCameraCell(picker: TLPhotosPickerViewController)
+    func deselectedPhoto(picker: TLPhotosPickerViewController, at: Int)
+    func selectedPhoto(picker: TLPhotosPickerViewController, at: Int)
+    func selectedAlbum(picker: TLPhotosPickerViewController, title: String, at: Int)
 }
 extension TLPhotosPickerViewControllerDelegate {
     public func deninedAuthoization() { }
@@ -29,6 +35,11 @@ extension TLPhotosPickerViewControllerDelegate {
     public func didExceedMaximumNumberOfSelection(picker: TLPhotosPickerViewController) { }
     public func handleNoAlbumPermissions(picker: TLPhotosPickerViewController) { }
     public func handleNoCameraPermissions(picker: TLPhotosPickerViewController) { }
+    
+    func selectedCameraCell(picker: TLPhotosPickerViewController) { }
+    func deselectedPhoto(picker: TLPhotosPickerViewController, at: Int) { }
+    func selectedPhoto(picker: TLPhotosPickerViewController, at: Int) { }
+    func selectedAlbum(picker: TLPhotosPickerViewController, collections: [TLAssetsCollection], at: Int) { }
 }
 
 public struct TLPhotosPickerConfigure {
@@ -703,6 +714,8 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
                 if let nibName = self.configure.cameraCellNibSet?.nibName {
                     cell.selectedCell()
                 }else {
+                    delegate?.selectedCameraCell(picker: self)
+                    
                     showCameraIfAuthorized()
                 }
                 return
@@ -712,6 +725,8 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
         cell.popScaleAnim()
         if let index = self.selectedAssets.index(where: { $0.phAsset == asset.phAsset }) {
         //deselect
+            delegate?.deselectedPhoto(picker: self, at: indexPath.row)
+            
             self.selectedAssets.remove(at: index)
             self.selectedAssets = self.selectedAssets.enumerated().flatMap({ (offset,asset) -> TLPHAsset? in
                 var asset = asset
@@ -726,6 +741,8 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
             }
         }else {
         //select
+            delegate?.selectedPhoto(picker: self, at: indexPath.row)
+            
             guard !maxCheck() else { return }
             asset.selectedOrder = self.selectedAssets.count + 1
             self.selectedAssets.append(asset)
@@ -904,6 +921,8 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
 extension TLPhotosPickerViewController: UITableViewDelegate,UITableViewDataSource {
     //delegate
     open func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        self.delegate?.selectedAlbum(picker: self, title: self.collections[indexPath.row].title, at: indexPath.row)
+        
         self.focused(collection: self.collections[indexPath.row])
     }
     


### PR DESCRIPTION
I tried to collect logs by customizing the TLPhotosPickerViewController.
But because focusedCollection and collections properties are private, I cannot differentiate whether user selected camera cell, selected cell or deselected cell. And I also cannot get information on collection when user tapped a album because of same reason.
I think others also need to collect logs on the user event.
I will be so grateful if I can collect the logs on user events.
