### PR TITLE
Adding the possibility to fix a required size

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
+++ b/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
@@ -32,6 +32,21 @@ open class TLPlayerView: UIView {
 open class TLPhotoCollectionViewCell: UICollectionViewCell {
     private var observer: NSObjectProtocol?
     @IBOutlet open var imageView: UIImageView?
+    @IBOutlet weak var requiredSizeMessageView: UIView! {
+        didSet {
+            self.requiredSizeMessageView.isHidden = true
+            self.requiredSizeMessageView.backgroundColor = UIColor.white.withAlphaComponent(0.95)
+        }
+    }
+    @IBOutlet weak var requiredSizeLabel: UILabel! {
+        didSet {
+            self.requiredSizeLabel.text = ""
+            self.requiredSizeLabel.numberOfLines = 0
+            self.requiredSizeLabel.isHidden = true
+            self.requiredSizeLabel.textColor = UIColor.black
+            self.requiredSizeLabel.font = self.requiredSizeLabel.font.withSize(12.0)
+        }
+    }
     @IBOutlet open var playerView: TLPlayerView?
     @IBOutlet open var livePhotoView: PHLivePhotoView?
     @IBOutlet open var liveBadgeImageView: UIImageView?
@@ -53,6 +68,18 @@ open class TLPhotoCollectionViewCell: UICollectionViewCell {
     }
     
     @objc open var isCameraCell = false
+    @objc open var currentSize = CGSize.zero
+    @objc open var unsatisfiedSize = false {
+        didSet {
+            self.requiredSizeMessageView.isHidden = !unsatisfiedSize
+            self.requiredSizeLabel.isHidden = !unsatisfiedSize
+            if unsatisfiedSize {
+                self.requiredSizeLabel.text = "\(Int(currentSize.width)) \n X \n \(Int(currentSize.height))"
+            }else {
+                self.requiredSizeLabel.text = ""
+            }
+        }
+    }
     
     open var duration: TimeInterval? {
         didSet {

--- a/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.xib
+++ b/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -97,10 +97,29 @@
                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="DZc-ag-e55">
                         <rect key="frame" x="40" y="40" width="20" height="20"/>
                     </activityIndicatorView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PP2-Mu-Q7q">
+                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c3e-7l-OTa">
+                                <rect key="frame" x="8" y="8" width="84" height="84"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="c3e-7l-OTa" secondAttribute="bottom" constant="8" id="aLm-gL-37r"/>
+                            <constraint firstItem="c3e-7l-OTa" firstAttribute="leading" secondItem="PP2-Mu-Q7q" secondAttribute="leading" constant="8" id="cPH-g2-ARl"/>
+                            <constraint firstItem="c3e-7l-OTa" firstAttribute="top" secondItem="PP2-Mu-Q7q" secondAttribute="top" constant="8" id="caB-jb-4Q2"/>
+                            <constraint firstAttribute="trailing" secondItem="c3e-7l-OTa" secondAttribute="trailing" constant="8" id="fBG-V5-TKF"/>
+                        </constraints>
+                    </view>
                 </subviews>
             </view>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="vfk-Ao-TKR" secondAttribute="bottom" id="2gw-cO-5bN"/>
+                <constraint firstItem="PP2-Mu-Q7q" firstAttribute="leading" secondItem="IF3-4e-v0j" secondAttribute="leading" id="2kY-1x-twJ"/>
                 <constraint firstAttribute="bottom" secondItem="aju-ob-KlZ" secondAttribute="bottom" id="2wo-Ki-15d"/>
                 <constraint firstAttribute="trailing" secondItem="aju-ob-KlZ" secondAttribute="trailing" id="2zm-kD-GPn"/>
                 <constraint firstAttribute="bottom" secondItem="apl-2Q-Hz7" secondAttribute="bottom" id="3zu-V3-EAd"/>
@@ -115,13 +134,16 @@
                 <constraint firstItem="vfk-Ao-TKR" firstAttribute="leading" secondItem="IF3-4e-v0j" secondAttribute="leading" id="NOQ-KU-fHD"/>
                 <constraint firstItem="vfk-Ao-TKR" firstAttribute="top" secondItem="IF3-4e-v0j" secondAttribute="top" id="NrV-wc-c3q"/>
                 <constraint firstItem="d1a-KW-Ta4" firstAttribute="height" secondItem="IF3-4e-v0j" secondAttribute="height" constant="10" id="VMJ-Qp-D4N"/>
+                <constraint firstAttribute="bottom" secondItem="PP2-Mu-Q7q" secondAttribute="bottom" id="XlZ-qy-IJC"/>
                 <constraint firstItem="apl-2Q-Hz7" firstAttribute="leading" secondItem="IF3-4e-v0j" secondAttribute="leading" id="bsL-0J-0Y5"/>
                 <constraint firstItem="d1a-KW-Ta4" firstAttribute="width" secondItem="IF3-4e-v0j" secondAttribute="width" constant="10" id="clS-DI-jvL"/>
                 <constraint firstItem="d1a-KW-Ta4" firstAttribute="top" secondItem="IF3-4e-v0j" secondAttribute="top" constant="-5" id="d3r-HZ-6We"/>
                 <constraint firstItem="DZc-ag-e55" firstAttribute="centerX" secondItem="IF3-4e-v0j" secondAttribute="centerX" id="fnn-1c-fSn"/>
+                <constraint firstAttribute="trailing" secondItem="PP2-Mu-Q7q" secondAttribute="trailing" id="mkd-hv-SQp"/>
                 <constraint firstItem="DZc-ag-e55" firstAttribute="centerY" secondItem="IF3-4e-v0j" secondAttribute="centerY" id="qZc-2h-nOx"/>
                 <constraint firstItem="d1a-KW-Ta4" firstAttribute="leading" secondItem="IF3-4e-v0j" secondAttribute="leading" constant="-5" id="sOj-ms-Oo3"/>
                 <constraint firstItem="0cR-fZ-1bW" firstAttribute="top" secondItem="IF3-4e-v0j" secondAttribute="top" id="sSC-fd-MoT"/>
+                <constraint firstItem="PP2-Mu-Q7q" firstAttribute="top" secondItem="IF3-4e-v0j" secondAttribute="top" id="sal-PX-smQ"/>
                 <constraint firstAttribute="bottom" secondItem="0cR-fZ-1bW" secondAttribute="bottom" id="xzA-tS-EVK"/>
             </constraints>
             <connections>
@@ -134,6 +156,8 @@
                 <outlet property="orderBgView" destination="hbA-dR-I09" id="cQo-BP-xh1"/>
                 <outlet property="orderLabel" destination="Weu-ef-IZ5" id="B3t-X5-o3a"/>
                 <outlet property="playerView" destination="apl-2Q-Hz7" id="vTI-ie-mcV"/>
+                <outlet property="requiredSizeLabel" destination="c3e-7l-OTa" id="OlM-Uz-yh7"/>
+                <outlet property="requiredSizeMessageView" destination="PP2-Mu-Q7q" id="5cJ-s9-R2s"/>
                 <outlet property="selectedHeight" destination="VMJ-Qp-D4N" id="uVe-tQ-4q5"/>
                 <outlet property="selectedView" destination="d1a-KW-Ta4" id="c31-4y-72g"/>
                 <outlet property="videoIconImageView" destination="Uzf-HJ-aUY" id="d7e-Bl-181"/>

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -32,6 +32,19 @@ extension TLPhotosPickerViewControllerDelegate {
     public func handleNoCameraPermissions(picker: TLPhotosPickerViewController) { }
 }
 
+extension UIViewController {
+    
+    func presentAlertWithTitle(title: String, message: String, options: String..., completion: @escaping (Int) -> Void) {
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        for (index, option) in options.enumerated() {
+            alertController.addAction(UIAlertAction.init(title: option, style: .default, handler: { (action) in
+                completion(index)
+            }))
+        }
+        self.present(alertController, animated: true, completion: nil)
+    }
+}
+
 //for log
 public protocol TLPhotosPickerLogDelegate: class {
     func selectedCameraCell(picker: TLPhotosPickerViewController)
@@ -54,6 +67,8 @@ public struct TLPhotosPickerConfigure {
     public var cancelTitle = "Cancel"
     public var doneTitle = "Done"
     public var emptyMessage = "No albums"
+    public var unsatisifiedSizeTitle = "Oups!"
+    public var unsatisifiedSizeMessage = "The required size is:"
     public var emptyImage: UIImage? = nil
     public var usedCameraButton = true
     public var usedPrefetch = false
@@ -73,6 +88,7 @@ public struct TLPhotosPickerConfigure {
     public var cameraBgColor = UIColor(red: 221/255, green: 223/255, blue: 226/255, alpha: 1)
     public var cameraIcon = TLBundle.podBundleImage(named: "camera")
     public var videoIcon = TLBundle.podBundleImage(named: "video")
+    public var requiredSize: CGSize?
     public var placeholderIcon = TLBundle.podBundleImage(named: "insertPhotoMaterial")
     public var nibSet: (nibName: String, bundle:Bundle)? = nil
     public var cameraCellNibSet: (nibName: String, bundle:Bundle)? = nil
@@ -378,16 +394,16 @@ extension TLPhotosPickerViewController {
                     cell.indicator?.startAnimating()
                 }
             }, completionBlock: { [weak self] image in
-                guard let `self` = self else { return }
-                asset.state = .complete
-                if let index = self.selectedAssets.index(where: { $0.phAsset == phAsset }) {
-                    self.selectedAssets[index] = asset
-                }
-                self.cloudRequestIds.removeValue(forKey: indexPath)
-                guard self.collectionView.indexPathsForVisibleItems.contains(indexPath) else { return }
-                guard let cell = self.collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell else { return }
-                cell.imageView?.image = image
-                cell.indicator?.stopAnimating()
+                    guard let `self` = self else { return }
+                    asset.state = .complete
+                    if let index = self.selectedAssets.index(where: { $0.phAsset == phAsset }) {
+                        self.selectedAssets[index] = asset
+                    }
+                    self.cloudRequestIds.removeValue(forKey: indexPath)
+                    guard self.collectionView.indexPathsForVisibleItems.contains(indexPath) else { return }
+                    guard let cell = self.collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell else { return }
+                    cell.imageView?.image = image
+                    cell.indicator?.stopAnimating()
             })
             if requestId > 0 {
                 self.cloudRequestIds[indexPath] = requestId
@@ -518,7 +534,7 @@ extension TLPhotosPickerViewController: UIImagePickerControllerDelegate, UINavig
             self.handleDeniedCameraAuthorization()
         }
     }
-
+    
     fileprivate func showCamera() {
         guard !maxCheck() else { return }
         let picker = UIImagePickerController()
@@ -535,7 +551,7 @@ extension TLPhotosPickerViewController: UIImagePickerControllerDelegate, UINavig
         picker.delegate = self
         self.present(picker, animated: true, completion: nil)
     }
-
+    
     fileprivate func handleDeniedAlbumsAuthorization() {
         self.delegate?.handleNoAlbumPermissions(picker: self)
         self.handleNoAlbumPermissions?(self)
@@ -614,8 +630,8 @@ extension TLPhotosPickerViewController {
         }
         #else
         let boundAssets = visibleIndexPaths.flatMap{ indexPath -> (IndexPath,TLPHAsset)? in
-            guard let asset = self.focusedCollection?.getTLAsset(at: indexPath.row),asset.phAsset?.mediaType == .video else { return nil }
-            return (indexPath,asset)
+        guard let asset = self.focusedCollection?.getTLAsset(at: indexPath.row),asset.phAsset?.mediaType == .video else { return nil }
+        return (indexPath,asset)
         }
         #endif
         if let firstSelectedVideoAsset = (boundAssets.filter{ getSelectedAssets($0.1) != nil }.first) {
@@ -700,14 +716,14 @@ extension TLPhotosPickerViewController: PHPhotoLibraryChangeObserver {
                 })
                 #else
                 self.selectedAssets = self.selectedAssets.enumerated().flatMap({ (offset,asset) -> TLPHAsset? in
-                    var asset = asset
-                    if let phAsset = asset.phAsset, changes.fetchResultAfterChanges.contains(phAsset) {
-                        order += 1
-                        asset.selectedOrder = order
-                        return asset
-                    }
-                    deletedSelectedAssets = true
-                    return nil
+                var asset = asset
+                if let phAsset = asset.phAsset, changes.fetchResultAfterChanges.contains(phAsset) {
+                order += 1
+                asset.selectedOrder = order
+                return asset
+                }
+                deletedSelectedAssets = true
+                return nil
                 })
                 #endif
                 if deletedSelectedAssets {
@@ -766,6 +782,13 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
     //Delegate
     open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let collection = self.focusedCollection, let cell = self.collectionView.cellForItem(at: indexPath) as? TLPhotoCollectionViewCell else { return }
+        
+        guard !cell.unsatisfiedSize else {
+            // Show the error message
+            self.presentAlertWithTitle(title: configure.unsatisifiedSizeTitle, message: "\(configure.unsatisifiedSizeMessage) \(Int(configure.requiredSize!.width)) x \(Int(configure.requiredSize!.height))", options: "OK") { _ in }
+            return
+        }
+        
         if collection.useCameraButton && indexPath.row == 0 {
             if Platform.isSimulator {
                 print("not supported by the simulator.")
@@ -783,7 +806,7 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
         guard var asset = collection.getTLAsset(at: indexPath.row) else { return }
         cell.popScaleAnim()
         if let index = self.selectedAssets.index(where: { $0.phAsset == asset.phAsset }) {
-        //deselect
+            //deselect
             self.logDelegate?.deselectedPhoto(picker: self, at: indexPath.row)
             self.selectedAssets.remove(at: index)
             #if swift(>=4.1)
@@ -794,9 +817,9 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
             })
             #else
             self.selectedAssets = self.selectedAssets.enumerated().flatMap({ (offset,asset) -> TLPHAsset? in
-                var asset = asset
-                asset.selectedOrder = offset + 1
-                return asset
+            var asset = asset
+            asset.selectedOrder = offset + 1
+            return asset
             })
             #endif
             cell.selectedAsset = false
@@ -807,7 +830,7 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
                 stopPlay()
             }
         }else {
-        //select
+            //select
             self.logDelegate?.selectedPhoto(picker: self, at: indexPath.row)
             guard !maxCheck() else { return }
             asset.selectedOrder = self.selectedAssets.count + 1
@@ -868,6 +891,7 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
         }else {
             cell.indicator?.stopAnimating()
         }
+        
         if let phAsset = asset.phAsset {
             if self.usedPrefetch {
                 let options = PHImageRequestOptions()
@@ -917,6 +941,13 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
             if self.allowedLivePhotos {
                 cell.liveBadgeImageView?.image = asset.type == .livePhoto ? PHLivePhotoView.livePhotoBadgeImage(options: .overContent) : nil
                 cell.livePhotoView?.delegate = asset.type == .livePhoto ? self : nil
+            }
+            
+            if let requiredSize = configure.requiredSize, (CGFloat(phAsset.pixelHeight) < requiredSize.height || CGFloat(phAsset.pixelWidth) < requiredSize.width) {
+                cell.currentSize = CGSize(width: CGFloat(phAsset.pixelWidth), height: CGFloat(phAsset.pixelHeight))
+                cell.unsatisfiedSize = true
+            }else {
+                cell.unsatisfiedSize = false
             }
         }
         cell.alpha = 0


### PR DESCRIPTION
Hi, 

In my application, I had to ignore some photos with unsatisfied size, that’s why I create this pull request.

Firstly, I added two configurations: `public var requiredSize: CGSize?`.

So, in the `cellForItemAt` method for collection view, I used the `phAsset. pixelHeight` and `phAsset. pixelWidth` to check the size. 

If the size is not conformed to `requiredSize`, I set the property (a new property) `unsatisfiedSize` for `TLPhotoCollectionViewCell` to false.

When this property is set and in the `didSet` method, I check if the value is `true` or `false` and according to this value, I show or not an overlay with the current image size. 

On cell selection, if this property (`unsatisfiedSize`) is set to false, I show a message in an alert. The title of this alert and the message can be configured with these two new configurations: `unsatisifiedSizeTitle` and `unsatisifiedSizeMessage`
