### PR TITLE
Adding the possibility to handle cell display according to a specific…

### DIFF
--- a/Example/TLPhotoPicker/Base.lproj/Main.storyboard
+++ b/Example/TLPhotoPicker/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="3bJ-bG-tue">
-                                <rect key="frame" x="73" y="230" width="229" height="208"/>
+                                <rect key="frame" x="73" y="187" width="229" height="294"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zpy-9h-CPz">
                                         <rect key="frame" x="0.0" y="0.0" width="229" height="36"/>
@@ -47,10 +47,20 @@
                                             <action selector="pickerWithNavigation" destination="vXZ-lx-hvc" eventType="touchUpInside" id="f8Y-zB-W7o"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VP9-SK-f4B">
+                                        <rect key="frame" x="0.0" y="258" width="229" height="36"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <state key="normal" title="with custom rules">
+                                            <color key="titleColor" red="0.27450980390000002" green="0.31372549020000001" blue="0.37647058820000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="pickerWithCustomRules" destination="vXZ-lx-hvc" eventType="touchUpInside" id="fAg-D7-tIw"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="u8O-io-kHd">
-                                <rect key="frame" x="137.5" y="448" width="100" height="112"/>
+                                <rect key="frame" x="137.5" y="491" width="100" height="112"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="get image message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9CM-MS-96X">
                                         <rect key="frame" x="3" y="0.0" width="94" height="12"/>

--- a/Example/TLPhotoPicker/CustomCell_Instagram.swift
+++ b/Example/TLPhotoPicker/CustomCell_Instagram.swift
@@ -12,6 +12,9 @@ import PhotosUI
 
 class CustomCell_Instagram: TLPhotoCollectionViewCell {
     
+    @IBOutlet var sizeRequiredLabel: UILabel!
+    @IBOutlet var sizeRequiredOverlayView: UIView!
+    
     let selectedColor = UIColor(red: 88/255, green: 144/255, blue: 255/255, alpha: 1.0)
     
     override var duration: TimeInterval? {
@@ -35,8 +38,15 @@ class CustomCell_Instagram: TLPhotoCollectionViewCell {
         }
     }
     
+    override func update(with phAsset: PHAsset) {
+        super.update(with: phAsset)
+        self.sizeRequiredOverlayView?.isHidden = !(phAsset.pixelHeight <= 300 && phAsset.pixelWidth <= 300)
+    }
+    
     override func awakeFromNib() {
         super.awakeFromNib()
+        self.sizeRequiredOverlayView?.isHidden = true
+        self.sizeRequiredLabel?.text = "100\nx\n100"
         self.durationView?.backgroundColor = UIColor.clear
         self.orderLabel?.clipsToBounds = true
         self.orderLabel?.layer.cornerRadius = 10

--- a/Example/TLPhotoPicker/CustomCell_Instagram.xib
+++ b/Example/TLPhotoPicker/CustomCell_Instagram.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -66,11 +66,32 @@
                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="1Zf-X9-xCZ">
                         <rect key="frame" x="40" y="40" width="20" height="20"/>
                     </activityIndicatorView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Qy3-sb-58T">
+                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lfL-bL-sYk">
+                                <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="0.80012103873239437" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="lfL-bL-sYk" firstAttribute="leading" secondItem="Qy3-sb-58T" secondAttribute="leading" id="1z3-FD-Zxw"/>
+                            <constraint firstItem="lfL-bL-sYk" firstAttribute="centerX" secondItem="Qy3-sb-58T" secondAttribute="centerX" id="3V8-tp-MzM"/>
+                            <constraint firstAttribute="bottom" secondItem="lfL-bL-sYk" secondAttribute="bottom" id="NIy-EZ-C5n"/>
+                            <constraint firstItem="lfL-bL-sYk" firstAttribute="centerY" secondItem="Qy3-sb-58T" secondAttribute="centerY" id="PbD-tZ-Mam"/>
+                            <constraint firstItem="lfL-bL-sYk" firstAttribute="top" secondItem="Qy3-sb-58T" secondAttribute="top" id="WPD-HJ-PeA"/>
+                            <constraint firstAttribute="trailing" secondItem="lfL-bL-sYk" secondAttribute="trailing" id="l92-O5-rxg"/>
+                        </constraints>
+                    </view>
                 </subviews>
             </view>
             <constraints>
                 <constraint firstItem="1Zf-X9-xCZ" firstAttribute="centerX" secondItem="9Rv-Fn-yCT" secondAttribute="centerX" id="4EP-vr-Yn3"/>
                 <constraint firstItem="dN5-jZ-SiB" firstAttribute="leading" secondItem="9Rv-Fn-yCT" secondAttribute="leading" id="81d-II-POL"/>
+                <constraint firstItem="Qy3-sb-58T" firstAttribute="leading" secondItem="9Rv-Fn-yCT" secondAttribute="leading" id="GfG-Mo-0Sm"/>
                 <constraint firstItem="rOH-JI-pE1" firstAttribute="leading" secondItem="9Rv-Fn-yCT" secondAttribute="leading" id="KJ3-eV-OY7"/>
                 <constraint firstAttribute="trailing" secondItem="dN5-jZ-SiB" secondAttribute="trailing" id="Mbt-2E-UCm"/>
                 <constraint firstItem="uwg-fz-Lnl" firstAttribute="leading" secondItem="9Rv-Fn-yCT" secondAttribute="leading" id="N99-b3-cRO"/>
@@ -79,15 +100,20 @@
                 <constraint firstItem="1Zf-X9-xCZ" firstAttribute="centerY" secondItem="9Rv-Fn-yCT" secondAttribute="centerY" id="Ti5-PE-sjK"/>
                 <constraint firstItem="rOH-JI-pE1" firstAttribute="top" secondItem="9Rv-Fn-yCT" secondAttribute="top" id="ZZd-iV-jqo"/>
                 <constraint firstAttribute="bottom" secondItem="rOH-JI-pE1" secondAttribute="bottom" id="ZfF-qA-gEg"/>
+                <constraint firstAttribute="trailing" secondItem="Qy3-sb-58T" secondAttribute="trailing" id="aYu-Lb-GuV"/>
                 <constraint firstAttribute="bottom" secondItem="uwg-fz-Lnl" secondAttribute="bottom" id="dGK-ts-Oxc"/>
                 <constraint firstAttribute="trailing" secondItem="uwg-fz-Lnl" secondAttribute="trailing" id="dkB-IK-EYy"/>
                 <constraint firstItem="uwg-fz-Lnl" firstAttribute="top" secondItem="9Rv-Fn-yCT" secondAttribute="top" id="izZ-b1-P9h"/>
+                <constraint firstItem="Qy3-sb-58T" firstAttribute="top" secondItem="9Rv-Fn-yCT" secondAttribute="top" id="nkP-eF-69q"/>
+                <constraint firstAttribute="bottom" secondItem="Qy3-sb-58T" secondAttribute="bottom" id="z9j-F5-guo"/>
             </constraints>
             <connections>
                 <outlet property="durationLabel" destination="0AD-DJ-hk7" id="fAK-hF-IpB"/>
                 <outlet property="imageView" destination="rOH-JI-pE1" id="tgu-TV-hTi"/>
                 <outlet property="indicator" destination="1Zf-X9-xCZ" id="b7n-5J-KNK"/>
                 <outlet property="orderLabel" destination="JhX-P9-VnM" id="Oev-lS-XRO"/>
+                <outlet property="sizeRequiredLabel" destination="lfL-bL-sYk" id="9nb-m4-mO4"/>
+                <outlet property="sizeRequiredOverlayView" destination="Qy3-sb-58T" id="5pf-6A-D4B"/>
             </connections>
             <point key="canvasLocation" x="32" y="-10"/>
         </collectionViewCell>

--- a/Example/TLPhotoPicker/ViewController.swift
+++ b/Example/TLPhotoPicker/ViewController.swift
@@ -61,6 +61,28 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
         self.present(viewController.wrapNavigationControllerWithoutBar(), animated: true, completion: nil)
     }
     
+    @IBAction func pickerWithCustomRules() {
+        let viewController = PhotoPickerWithNavigationViewController()
+        viewController.delegate = self
+        viewController.didExceedMaximumNumberOfSelection = { [weak self] (picker) in
+            self?.showExceededMaximumAlert(vc: picker)
+        }
+        viewController.canSelectAsset = { [weak self] asset -> Bool in
+            if asset.pixelHeight < 100 || asset.pixelWidth < 100 {
+                self?.showUnsatisifiedSizeAlert(vc: viewController)
+                return false
+            }
+            return true
+        }
+        var configure = TLPhotosPickerConfigure()
+        configure.numberOfColumn = 3
+        configure.nibSet = (nibName: "CustomCell_Instagram", bundle: Bundle.main)
+        viewController.configure = configure
+        viewController.selectedAssets = self.selectedAssets
+        
+        self.present(viewController.wrapNavigationControllerWithoutBar(), animated: true, completion: nil)
+    }
+    
     func dismissPhotoPicker(withTLPHAssets: [TLPHAsset]) {
         // use selected order, fullresolution image
         self.selectedAssets = withTLPHAssets
@@ -155,6 +177,12 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
 
     func showExceededMaximumAlert(vc: UIViewController) {
         let alert = UIAlertController(title: "", message: "Exceed Maximum Number Of Selection", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
+        vc.present(alert, animated: true, completion: nil)
+    }
+    
+    func showUnsatisifiedSizeAlert(vc: UIViewController) {
+        let alert = UIAlertController(title: "Oups!", message: "The required size is: 100 x 100", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
         vc.present(alert, animated: true, completion: nil)
     }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ TLPhotoPicker enables application to pick images and videos from multiple smart 
 - async phasset request and displayed cell.
   - scrolling performance is better than facebook in displaying video assets collection.
 - custom cell
+- custom display and selection rules
 - reload of changes that occur in the Photos library.
 - support iCloud Photo Library
 
@@ -71,7 +72,9 @@ github "tilltue/TLPhotoPicker"
 <img src="./Images/Privacy.png">
 
 ## Usage 
-- use delegate & custom cell
+
+**use delegate & custom cell**
+
 ```swift 
 class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
     var selectedAssets = [TLPHAsset]()
@@ -120,8 +123,40 @@ class CustomCell_Instagram: TLPhotoCollectionViewCell {
 @objc open func selectedCell()
 @objc open func willDisplayCell()
 @objc open func endDisplayingCell()
+
 ```
-- use closure
+
+**Custom Rules & Display**
+
+You can implement your own rules to handle the cell display. You can decide in which case the selection of the cell could be forbidden. 
+
+For example, if you want to disable the selection of a cell if its width is under 300, you can follow these steps:
+
+- Override the update method of your custom cell and add your own display rule 
+
+```swift
+override func update(with phAsset: PHAsset) {
+    super.update(with: phAsset)
+    self.sizeRequiredOverlayView?.isHidden = !(phAsset.pixelHeight <= 300 && phAsset.pixelWidth <= 300)
+}
+``` 
+In this code, we show an overlay when the height and width required values are not satisified.
+
+- When you instanciate a `TLPhotosPickerViewController` subclass, you can pass a closure called `canSelectAsset` to handle the selection according to some rules. 
+
+```Swift
+viewController.canSelectAsset = { [weak self] asset -> Bool in
+    if asset.pixelHeight < 100 || asset.pixelWidth < 100 {
+        self?.showUnsatisifiedSizeAlert(vc: viewController)
+        return false
+    }
+    return true
+}
+```
+In this code, we show an alert when the condition in the closure are not satisfiied.
+
+**use closure**
+
 ```swift
     convenience public init(withPHAssets: (([PHAsset]) -> Void)? = nil, didCancel: ((Void) -> Void)? = nil)
     convenience public init(withTLPHAssets: (([TLPHAsset]) -> Void)? = nil, didCancel: ((Void) -> Void)? = nil)
@@ -152,7 +187,9 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
 }
 
 ```
-- TLPHAsset
+
+**TLPHAsset**
+
 ```swift
 public struct TLPHAsset {
     public enum AssetType {

--- a/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
+++ b/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
@@ -118,6 +118,10 @@ open class TLPhotoCollectionViewCell: UICollectionViewCell {
         }
     }
     
+    @objc open func update(with phAsset: PHAsset) {
+        
+    }
+    
     @objc open func selectedCell() {
         
     }

--- a/TLPhotoPicker/Classes/TLPhotoLibrary.swift
+++ b/TLPhotoPicker/Classes/TLPhotoLibrary.swift
@@ -135,7 +135,8 @@ extension TLPhotoLibrary {
         
         let options = configure.fetchOption ?? PHFetchOptions()
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-        
+        let requiredSizePredicate = NSPredicate(format: "pixelHeight > %d AND pixelWidth > %d", 300,300)
+        options.merge(predicate: requiredSizePredicate)
         if let mediaType = configure.mediaType {
             let mediaTypePredicate = configure.maxVideoDuration != nil && mediaType == PHAssetMediaType.video ? NSPredicate(format: "mediaType = %i AND duration < %f", mediaType.rawValue, configure.maxVideoDuration! + 1) : NSPredicate(format: "mediaType = %i", mediaType.rawValue)
             options.merge(predicate: mediaTypePredicate)

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -16,6 +16,7 @@ public protocol TLPhotosPickerViewControllerDelegate: class {
     func dismissPhotoPicker(withTLPHAssets: [TLPHAsset])
     func dismissComplete()
     func photoPickerDidCancel()
+    func handleCellSelection(phAsset: PHAsset) -> Bool
     func didExceedMaximumNumberOfSelection(picker: TLPhotosPickerViewController)
     func handleNoAlbumPermissions(picker: TLPhotosPickerViewController)
     func handleNoCameraPermissions(picker: TLPhotosPickerViewController)
@@ -27,6 +28,7 @@ extension TLPhotosPickerViewControllerDelegate {
     public func dismissPhotoPicker(withTLPHAssets: [TLPHAsset]) { }
     public func dismissComplete() { }
     public func photoPickerDidCancel() { }
+    public func handleCellSelection(phAsset: PHAsset) -> Bool { return true }
     public func didExceedMaximumNumberOfSelection(picker: TLPhotosPickerViewController) { }
     public func handleNoAlbumPermissions(picker: TLPhotosPickerViewController) { }
     public func handleNoCameraPermissions(picker: TLPhotosPickerViewController) { }
@@ -140,6 +142,7 @@ open class TLPhotosPickerViewController: UIViewController {
             self.configure.allowedLivePhotos = newValue
         }
     }
+    @objc open var canSelectAsset: ((PHAsset) -> Bool)? = nil
     @objc open var didExceedMaximumNumberOfSelection: ((TLPhotosPickerViewController) -> Void)? = nil
     @objc open var handleNoAlbumPermissions: ((TLPhotosPickerViewController) -> Void)? = nil
     @objc open var handleNoCameraPermissions: ((TLPhotosPickerViewController) -> Void)? = nil
@@ -454,6 +457,16 @@ extension TLPhotosPickerViewController {
             self?.dismissCompletion?()
         }
     }
+    
+    fileprivate func canSelect(phAsset: PHAsset) -> Bool {
+        if let closure = self.canSelectAsset {
+            return closure(phAsset)
+        }else if let delegate = self.delegate {
+            return delegate.handleCellSelection(phAsset: phAsset)
+        }
+        return true
+    }
+    
     fileprivate func maxCheck() -> Bool {
         if self.configure.singleSelectedMode {
             self.selectedAssets.removeAll()
@@ -780,7 +793,7 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
                 return
             }
         }
-        guard var asset = collection.getTLAsset(at: indexPath.row) else { return }
+        guard var asset = collection.getTLAsset(at: indexPath.row), let phAsset = asset.phAsset else { return }
         cell.popScaleAnim()
         if let index = self.selectedAssets.index(where: { $0.phAsset == asset.phAsset }) {
         //deselect
@@ -810,6 +823,7 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
         //select
             self.logDelegate?.selectedPhoto(picker: self, at: indexPath.row)
             guard !maxCheck() else { return }
+            guard canSelect(phAsset: phAsset) else { return }
             asset.selectedOrder = self.selectedAssets.count + 1
             self.selectedAssets.append(asset)
             //requestCloudDownload(asset: asset, indexPath: indexPath)
@@ -879,6 +893,7 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
                     DispatchQueue.main.async {
                         if self.requestIds[indexPath] != nil {
                             cell?.imageView?.image = image
+                            cell?.update(with: phAsset)
                             if self.allowedVideo {
                                 cell?.durationView?.isHidden = asset.type != .video
                                 cell?.duration = asset.type == .video ? phAsset.duration : nil
@@ -899,6 +914,7 @@ extension TLPhotosPickerViewController: UICollectionViewDelegate,UICollectionVie
                         DispatchQueue.main.async {
                             if self.requestIds[indexPath] != nil {
                                 cell?.imageView?.image = image
+                                cell?.update(with: phAsset)
                                 if self.allowedVideo {
                                     cell?.durationView?.isHidden = asset.type != .video
                                     cell?.duration = asset.type == .video ? phAsset.duration : nil


### PR DESCRIPTION
Further to our conversation (Adding the possibility to fix a required size[ #123](https://github.com/tilltue/TLPhotoPicker/pull/123)), please find this new PR. 
I also updated the documentation: 

You can implement your own rules to handle the cell display. You can decide in which case the selection of the cell could be forbidden. 

For example, if you want to disable the selection of a cell if its width is under 300, you can follow these steps:

- Override the update method of your custom cell and add your own display rule 

```swift
override func update(with phAsset: PHAsset) {
    super.update(with: phAsset)
    self.sizeRequiredOverlayView?.isHidden = !(phAsset.pixelHeight <= 300 && phAsset.pixelWidth <= 300)
}
``` 
In this code, we show an overlay when the height and width required values are not satisified.

- When you instanciate a `TLPhotosPickerViewController` subclass, you can pass a closure called `canSelectAsset` to handle the selection according to some rules. 

```Swift
viewController.canSelectAsset = { [weak self] asset -> Bool in
    if asset.pixelHeight < 100 || asset.pixelWidth < 100 {
        self?.showUnsatisifiedSizeAlert(vc: viewController)
        return false
    }
    return true
}
```
In this code, we show an alert when the condition in the closure are not satisfiied.