### PR TITLE
Autoscroll to default phasset in collection

### DIFF
--- a/Example/TLPhotoPicker.xcodeproj/project.pbxproj
+++ b/Example/TLPhotoPicker.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDC1AFB9204008FA782 /* Images.xcassets */; };
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
+		C3D7A9D620D8FB7700DDCE5F /* CustomPhotoPickeAutoScrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D7A9D520D8FB7700DDCE5F /* CustomPhotoPickeAutoScrollViewController.swift */; };
 		CB31335EFDE1A8586225CFE6 /* Pods_TLPhotoPicker_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83E119F9CCBD6D384998CB57 /* Pods_TLPhotoPicker_Example.framework */; };
 /* End PBXBuildFile section */
 
@@ -66,6 +67,7 @@
 		607FACEB1AFB9204008FA782 /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
 		83E119F9CCBD6D384998CB57 /* Pods_TLPhotoPicker_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TLPhotoPicker_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AED71020F992B2D2D76C0DCD /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		C3D7A9D520D8FB7700DDCE5F /* CustomPhotoPickeAutoScrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPhotoPickeAutoScrollViewController.swift; sourceTree = "<group>"; };
 		DF35E7F382136F073D03D766 /* TLPhotoPicker.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = TLPhotoPicker.podspec; path = ../TLPhotoPicker.podspec; sourceTree = "<group>"; };
 		F047F54580DD32436AB0F8F6 /* Pods-TLPhotoPicker_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TLPhotoPicker_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TLPhotoPicker_Example/Pods-TLPhotoPicker_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		FF774390FCDE758A51AF70EF /* Pods-TLPhotoPicker_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TLPhotoPicker_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-TLPhotoPicker_Example/Pods-TLPhotoPicker_Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 			isa = PBXGroup;
 			children = (
 				5D34B30D1F26367C00F22369 /* TLPhotosPicker+Extension.swift */,
+				C3D7A9D520D8FB7700DDCE5F /* CustomPhotoPickeAutoScrollViewController.swift */,
 				5D5573691EDA612200E5F509 /* CustomPhotoPickerViewController.swift */,
 				5D34B3131F2639CA00F22369 /* PhotoPickerWithNavigationViewController.swift */,
 				5D34B30F1F26370400F22369 /* ImagePreviewViewController.swift */,
@@ -435,6 +438,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5D438D831EC9DB9000D63583 /* CustomCell_Instagram.swift in Sources */,
+				C3D7A9D620D8FB7700DDCE5F /* CustomPhotoPickeAutoScrollViewController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				5DCDB0FA1FA966B400B8F92C /* PreviewView.swift in Sources */,
 				5D34B30E1F26367C00F22369 /* TLPhotosPicker+Extension.swift in Sources */,

--- a/Example/TLPhotoPicker.xcodeproj/project.pbxproj
+++ b/Example/TLPhotoPicker.xcodeproj/project.pbxproj
@@ -324,9 +324,19 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TLPhotoPicker_Tests/Pods-TLPhotoPicker_Tests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/FBSnapshotTestCase/FBSnapshotTestCase.framework",
+				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
+				"${BUILT_PRODUCTS_DIR}/Nimble-Snapshots/Nimble_Snapshots.framework",
+				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
+				"${BUILT_PRODUCTS_DIR}/iOSSnapshotTestCase/FBSnapshotTestCase.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSnapshotTestCase.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Nimble_Snapshots.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Quick.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -354,13 +364,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TLPhotoPicker_Tests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		A36072925E692C716EFD545A /* [CP] Check Pods Manifest.lock */ = {
@@ -369,13 +382,16 @@
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-TLPhotoPicker_Example-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		AF754356D1F77FE6A436D473 /* [CP] Copy Pods Resources */ = {
@@ -399,9 +415,12 @@
 			files = (
 			);
 			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-TLPhotoPicker_Example/Pods-TLPhotoPicker_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/TLPhotoPicker/TLPhotoPicker.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TLPhotoPicker.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Example/TLPhotoPicker/Base.lproj/Main.storyboard
+++ b/Example/TLPhotoPicker/Base.lproj/Main.storyboard
@@ -19,10 +19,10 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="50" translatesAutoresizingMaskIntoConstraints="NO" id="3bJ-bG-tue">
-                                <rect key="frame" x="73" y="187" width="229" height="294"/>
+                                <rect key="frame" x="10" y="144" width="355" height="380"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zpy-9h-CPz">
-                                        <rect key="frame" x="0.0" y="0.0" width="229" height="36"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="355" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="Show Picker"/>
                                         <connections>
@@ -30,7 +30,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="d6U-qB-bWX">
-                                        <rect key="frame" x="0.0" y="86" width="229" height="36"/>
+                                        <rect key="frame" x="0.0" y="86" width="355" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="Custom CameraCell (Live)"/>
                                         <connections>
@@ -38,7 +38,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="icR-mj-SY4">
-                                        <rect key="frame" x="0.0" y="172" width="229" height="36"/>
+                                        <rect key="frame" x="0.0" y="172" width="355" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="with NavigationController">
                                             <color key="titleColor" red="0.1019607843" green="0.73725490199999999" blue="0.61176470589999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -48,7 +48,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VP9-SK-f4B">
-                                        <rect key="frame" x="0.0" y="258" width="229" height="36"/>
+                                        <rect key="frame" x="0.0" y="258" width="355" height="36"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <state key="normal" title="with custom rules">
                                             <color key="titleColor" red="0.27450980390000002" green="0.31372549020000001" blue="0.37647058820000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -57,10 +57,21 @@
                                             <action selector="pickerWithCustomRules" destination="vXZ-lx-hvc" eventType="touchUpInside" id="fAg-D7-tIw"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sVo-8C-UCg">
+                                        <rect key="frame" x="0.0" y="344" width="355" height="36"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <state key="normal" title="Autoscroll to default phasset in collection">
+                                            <color key="titleColor" red="0.27450980390000002" green="0.31372549020000001" blue="0.37647058820000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="pickerWithAutoScroll" destination="vXZ-lx-hvc" eventType="touchUpInside" id="QMy-To-Fgq"/>
+                                            <action selector="pickerWithCustomRules" destination="vXZ-lx-hvc" eventType="touchUpInside" id="2a1-ho-u1c"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="u8O-io-kHd">
-                                <rect key="frame" x="137.5" y="491" width="100" height="112"/>
+                                <rect key="frame" x="137.5" y="534" width="100" height="112"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="get image message" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9CM-MS-96X">
                                         <rect key="frame" x="3" y="0.0" width="94" height="12"/>

--- a/Example/TLPhotoPicker/CustomCell_Instagram.swift
+++ b/Example/TLPhotoPicker/CustomCell_Instagram.swift
@@ -40,7 +40,7 @@ class CustomCell_Instagram: TLPhotoCollectionViewCell {
     
     override func update(with phAsset: PHAsset) {
         super.update(with: phAsset)
-        self.sizeRequiredOverlayView?.isHidden = (phAsset.pixelWidth == 300 && phAsset.pixelHeight == 300)
+        self.sizeRequiredOverlayView?.isHidden = (phAsset.pixelWidth > 300 && phAsset.pixelHeight > 300)
         self.sizeRequiredLabel?.text = "\(phAsset.pixelWidth)\nx\n\(phAsset.pixelHeight)"
     }
     

--- a/Example/TLPhotoPicker/CustomPhotoPickeAutoScrollViewController.swift
+++ b/Example/TLPhotoPicker/CustomPhotoPickeAutoScrollViewController.swift
@@ -1,27 +1,22 @@
 //
-//  PhotoPickerWithNavigationViewController.swift
-//  TLPhotoPicker
+//  PhotoPickeAutoScrollViewController.swift
+//  TLPhotoPicker_Example
 //
-//  Created by wade.hawk on 2017. 7. 24..
-//  Copyright © 2017년 CocoaPods. All rights reserved.
+//  Created by Ali ABBAS on 19/06/2018.
+//  Copyright © 2018 CocoaPods. All rights reserved.
 //
 
-import Foundation
+import UIKit
 import TLPhotoPicker
 
-class PhotoPickerWithNavigationViewController: TLPhotosPickerViewController {
+class CustomPhotoPickeAutoScrollViewController: TLPhotosPickerViewController {
     override func makeUI() {
         super.makeUI()
         self.customNavItem.leftBarButtonItem = UIBarButtonItem.init(barButtonSystemItem: .stop, target: nil, action: #selector(customAction))
     }
+    
     @objc func customAction() {
         self.dismiss(animated: true, completion: nil)
-    }
-    
-    override func doneButtonTap() {
-      let imagePreviewVC = ImagePreviewViewController()
-      imagePreviewVC.assets = self.selectedAssets.first
-      self.navigationController?.pushViewController(imagePreviewVC, animated: true)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -37,4 +32,5 @@ class PhotoPickerWithNavigationViewController: TLPhotosPickerViewController {
             self.navigationController?.setNavigationBarHidden(true, animated: true)
         }
     }
+
 }

--- a/Example/TLPhotoPicker/PhotoPickerWithNavigationViewController.swift
+++ b/Example/TLPhotoPicker/PhotoPickerWithNavigationViewController.swift
@@ -18,11 +18,12 @@ class PhotoPickerWithNavigationViewController: TLPhotosPickerViewController {
         self.dismiss(animated: true, completion: nil)
     }
     
-    override func doneButtonTap() {
-        let imagePreviewVC = ImagePreviewViewController()
-        imagePreviewVC.assets = self.selectedAssets.first
-        self.navigationController?.pushViewController(imagePreviewVC, animated: true)
-    }
+//    override func doneButtonTap() {
+//      super.doneButtonTap()
+//      let imagePreviewVC = ImagePreviewViewController()
+//      imagePreviewVC.assets = self.selectedAssets.first
+//      self.navigationController?.pushViewController(imagePreviewVC, animated: true)
+//    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)

--- a/Example/TLPhotoPicker/ViewController.swift
+++ b/Example/TLPhotoPicker/ViewController.swift
@@ -13,6 +13,8 @@ import Photos
 class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
     
     var selectedAssets = [TLPHAsset]()
+    var defaultPhotoLocalIdentifer: (collectionID: String, asset: PHAsset)?
+    
     @IBOutlet var label: UILabel!
     @IBOutlet var imageView: UIImageView!
     
@@ -68,19 +70,24 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
             self?.showExceededMaximumAlert(vc: picker)
         }
         viewController.canSelectAsset = { [weak self] asset -> Bool in
-            if asset.pixelHeight != 300 && asset.pixelWidth != 300 {
+            if asset.pixelHeight < 300 && asset.pixelWidth < 300 {
                 self?.showUnsatisifiedSizeAlert(vc: viewController)
                 return false
             }
             return true
         }
         var configure = TLPhotosPickerConfigure()
-        configure.numberOfColumn = 3
+        configure.numberOfColumn = 1
         configure.nibSet = (nibName: "CustomCell_Instagram", bundle: Bundle.main)
+        configure.defaultAsset = self.defaultPhotoLocalIdentifer
         viewController.configure = configure
         viewController.selectedAssets = self.selectedAssets
         
         self.present(viewController.wrapNavigationControllerWithoutBar(), animated: true, completion: nil)
+    }
+    
+    func dismissPhotoPicker(collection: PHAssetCollection?, withTLPHAssets: [TLPHAsset]) {
+        self.defaultPhotoLocalIdentifer = (collection?.localIdentifier, withTLPHAssets.first?.phAsset) as? (collectionID: String, asset: PHAsset)
     }
     
     func dismissPhotoPicker(withTLPHAssets: [TLPHAsset]) {

--- a/Example/TLPhotoPicker/ViewController.swift
+++ b/Example/TLPhotoPicker/ViewController.swift
@@ -13,7 +13,7 @@ import Photos
 class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
     
     var selectedAssets = [TLPHAsset]()
-    var defaultPhotoLocalIdentifer: (collectionID: String, asset: PHAsset)?
+    var defaultPhotoAsset: (collectionID: String, asset: PHAsset)?
     
     @IBOutlet var label: UILabel!
     @IBOutlet var imageView: UIImageView!
@@ -94,7 +94,7 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
         var configure = TLPhotosPickerConfigure()
         configure.numberOfColumn = 1
         configure.nibSet = (nibName: "CustomCell_Instagram", bundle: Bundle.main)
-        configure.defaultAsset = self.defaultPhotoLocalIdentifer
+        configure.defaultAsset = self.defaultPhotoAsset
         viewController.configure = configure
         viewController.selectedAssets = self.selectedAssets
         
@@ -102,7 +102,7 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
     }
     
     func dismissPhotoPicker(collection: PHAssetCollection?, withTLPHAssets: [TLPHAsset]) {
-        self.defaultPhotoLocalIdentifer = (collection?.localIdentifier, withTLPHAssets.first?.phAsset) as? (collectionID: String, asset: PHAsset)
+        self.defaultPhotoAsset = (collection?.localIdentifier, withTLPHAssets.first?.phAsset) as? (collectionID: String, asset: PHAsset)
     }
     
     func dismissPhotoPicker(withTLPHAssets: [TLPHAsset]) {

--- a/Example/TLPhotoPicker/ViewController.swift
+++ b/Example/TLPhotoPicker/ViewController.swift
@@ -79,6 +79,21 @@ class ViewController: UIViewController,TLPhotosPickerViewControllerDelegate {
         var configure = TLPhotosPickerConfigure()
         configure.numberOfColumn = 1
         configure.nibSet = (nibName: "CustomCell_Instagram", bundle: Bundle.main)
+        viewController.configure = configure
+        viewController.selectedAssets = self.selectedAssets
+        
+        self.present(viewController.wrapNavigationControllerWithoutBar(), animated: true, completion: nil)
+    }
+    
+    @IBAction func pickerWithAutoScroll() {
+        let viewController = CustomPhotoPickeAutoScrollViewController()
+        viewController.delegate = self
+        viewController.didExceedMaximumNumberOfSelection = { [weak self] (picker) in
+            self?.showExceededMaximumAlert(vc: picker)
+        }
+        var configure = TLPhotosPickerConfigure()
+        configure.numberOfColumn = 1
+        configure.nibSet = (nibName: "CustomCell_Instagram", bundle: Bundle.main)
         configure.defaultAsset = self.defaultPhotoLocalIdentifer
         viewController.configure = configure
         viewController.selectedAssets = self.selectedAssets

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.xib
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -38,6 +38,7 @@
             <subviews>
                 <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X8O-Gg-slz">
                     <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <items>
                         <navigationItem id="5CU-MZ-p1K">
                             <nil key="title"/>
@@ -193,7 +194,7 @@
                     </connections>
                 </view>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="HPm-Vc-F86" firstAttribute="bottom" secondItem="HLR-WT-D3I" secondAttribute="bottom" id="0AS-35-SWm"/>
                 <constraint firstItem="AEv-G6-dRI" firstAttribute="centerX" secondItem="Zyk-dI-msE" secondAttribute="centerX" id="44C-fd-MVc"/>


### PR DESCRIPTION
In some case, user can have a lot of images in the camera roll, maybe more than 5000. 

When I select photo for the first time on position 1200 for example and then I dismiss the view controller, I would like the view to auto scroll to around position 1200 when I will open it again. So, I don't have to search and scroll again. That's why I create this pull request. 

**In this pull request :** 

-I create a new view controller to test the new way to scroll to default index of assets : `CustomPhotoPickeAutoScrollViewController`
-I modify the delegate method : `dismissPhotoPicker(withTLPHAssets:)` in the `TLPhotosPickerViewControllerDelegate`to pass the identifier of the collection.
-In the ViewController class, I declared a var called `defaultPhotoAsset`. When we instantiate a configuration, we pass this value. When the view controller is dismissed, the `dismissPhotoPicker` method is called and we set the `defaultPhotoAsset` with its new parameters values : collection and asset. 

All your remarks on the implementation are welcome.