### PR TITLE
Grab a TLPHAsset by a local identifier

### DIFF
--- a/TLPhotoPicker/Classes/TLAssetsCollection.swift
+++ b/TLPhotoPicker/Classes/TLAssetsCollection.swift
@@ -271,6 +271,11 @@ public struct TLPHAsset {
     init(asset: PHAsset?) {
         self.phAsset = asset
     }
+
+    public static func asset(with localIdentifier: String) -> TLPHAsset? {
+        let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [localIdentifier], options: nil)
+        return TLPHAsset(asset: fetchResult.firstObject)
+    }
 }
 
 extension TLPHAsset: Equatable {


### PR DESCRIPTION
If you want to keep track of an image between app sessions, the best way to do it is with the localIdentifier. However, there's currently no way to get it back into the TLPHAsset like it was before because the TLPHAsset init method is internal.

I created a static method on TLPHAsset to grab an asset and return it as a TLPHAsset.

If for some reason the developer does not want this in their code, it would be great if they opened the TLPHAsset to public so it can be added (along with other similar use cases) easier.