### PR TITLE
Fix wrong predicate for allowedLivePhotos option

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotoLibrary.swift
+++ b/TLPhotoPicker/Classes/TLPhotoLibrary.swift
@@ -143,9 +143,7 @@ extension TLPhotoLibrary {
             options.merge(predicate: notVideoPredicate)
         }
         if configure.allowedLivePhotos == false {
-            let notLivePhotoPredicate = NSPredicate(format: "mediaType = %i OR mediaSubtype != %i",
-                                                    PHAssetMediaType.video.rawValue,
-                                                    PHAssetMediaSubtype.photoLive.rawValue)
+            let notLivePhotoPredicate = NSPredicate(format: "NOT ((mediaSubtype & %d) != 0)", PHAssetMediaSubtype.photoLive.rawValue)
             options.merge(predicate: notLivePhotoPredicate)
         }
         if let maxVideoDuration = configure.maxVideoDuration {


### PR DESCRIPTION
### TLPhotosPickerConfigure
```
configure.allowedVideo = false
configure.allowedLivePhotos = false
```

### TLPhotoLibrary.getOption(configure:)

#### AS-IS (TLPhotoPicker v1.7.8)
```
<PHFetchOptions: 0x10bee75f0> predicate=mediaType != 2 AND (mediaType == 2 OR mediaSubtype != 8), sort=(
    "(creationDate, descending, compare:)"
), wantsChangeDetails=1
```

#### TO-BE
```
<PHFetchOptions: 0x101e40a10> predicate=mediaType != 2 AND (NOT mediaSubtype & 8 != 0), sort=(
    "(creationDate, descending, compare:)"
), wantsChangeDetails=1
```