### PR TITLE
Fix iOS 13 white margin in dark mode

### DIFF
--- a/TLPhotoPicker/Classes/TLAlbumPopView.swift
+++ b/TLPhotoPicker/Classes/TLAlbumPopView.swift
@@ -52,7 +52,7 @@ extension PopupViewProtocol where Self: UIView {
     }
 }
 
-open class TLAlbumPopView: UIView,PopupViewProtocol {
+open class TLAlbumPopView: UIView, PopupViewProtocol {
     @IBOutlet open var bgView: UIView!
     @IBOutlet open var popupView: UIView!
     @IBOutlet var popupViewHeight: NSLayoutConstraint!
@@ -64,24 +64,15 @@ open class TLAlbumPopView: UIView,PopupViewProtocol {
 //        print("deinit TLAlbumPopView")
     }
     
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if #available(iOS 13.0, *) {
-            let userInterfaceStyle = self.traitCollection.userInterfaceStyle
-            if userInterfaceStyle.rawValue == 2 {
-                self.popupView.backgroundColor = .systemBackground
-            }else {
-                self.popupView.backgroundColor = .white
-            }
-        }
-    }
-    
     override open func awakeFromNib() {
         super.awakeFromNib()
         self.popupView.layer.cornerRadius = 5.0
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapBgView))
         self.bgView.addGestureRecognizer(tapGesture)
         self.tableView.register(UINib(nibName: "TLCollectionTableViewCell", bundle: TLBundle.bundle()), forCellReuseIdentifier: "TLCollectionTableViewCell")
+        if #available(iOS 13.0, *) {
+            self.popupView.backgroundColor = .systemBackground
+        }
     }
     
     @objc func tapBgView() {

--- a/TLPhotoPicker/Classes/TLCollectionTableViewCell.swift
+++ b/TLPhotoPicker/Classes/TLCollectionTableViewCell.swift
@@ -18,17 +18,8 @@ open class TLCollectionTableViewCell: UITableViewCell {
         if #available(iOS 11.0, *) {
             self.thumbImageView.accessibilityIgnoresInvertColors = true
         }
-    }
-    
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
         if #available(iOS 13.0, *) {
-            let userInterfaceStyle = self.traitCollection.userInterfaceStyle
-            if userInterfaceStyle.rawValue == 2 {
-                self.contentView.backgroundColor = .systemBackground
-            }else {
-                self.contentView.backgroundColor = .white
-            }
+            self.contentView.backgroundColor = .systemBackground
         }
     }
 }

--- a/TLPhotoPicker/Classes/TLCollectionTableViewCell.xib
+++ b/TLPhotoPicker/Classes/TLCollectionTableViewCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,24 +13,27 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="75"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9FY-S1-KKQ" id="UUZ-nI-xH1">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="74.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="75"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4Dk-kD-sMy">
-                        <rect key="frame" x="5" y="12.5" width="50" height="50"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="4Dk-kD-sMy">
+                        <rect key="frame" x="15" y="12.5" width="50" height="50"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="50" id="yiu-ZU-58w"/>
+                            <constraint firstAttribute="width" constant="50" id="zAc-Fo-aGe"/>
+                        </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="7nv-2U-xMp">
-                        <rect key="frame" x="69" y="19" width="248" height="36.5"/>
+                        <rect key="frame" x="75" y="19.5" width="235" height="36.5"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Camera Roll" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ES8-Tq-6Wz">
-                                <rect key="frame" x="0.0" y="0.0" width="248" height="17"/>
+                                <rect key="frame" x="0.0" y="0.0" width="235" height="17"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="9999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NuJ-3w-ZAP">
-                                <rect key="frame" x="0.0" y="22" width="248" height="14.5"/>
+                                <rect key="frame" x="0.0" y="22" width="235" height="14.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" red="0.43137254901960786" green="0.43137254901960786" blue="0.43137254901960786" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -42,9 +42,11 @@
                     </stackView>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="4Dk-kD-sMy" firstAttribute="leading" secondItem="UUZ-nI-xH1" secondAttribute="leading" constant="15" id="7W9-hT-caE"/>
                     <constraint firstItem="7nv-2U-xMp" firstAttribute="centerY" secondItem="UUZ-nI-xH1" secondAttribute="centerY" id="E6U-ch-GDV"/>
-                    <constraint firstItem="7nv-2U-xMp" firstAttribute="leading" secondItem="UUZ-nI-xH1" secondAttribute="leadingMargin" constant="61" id="Jsu-Hd-Sg3"/>
                     <constraint firstAttribute="trailingMargin" secondItem="7nv-2U-xMp" secondAttribute="trailing" constant="50" id="T3U-hj-718"/>
+                    <constraint firstItem="4Dk-kD-sMy" firstAttribute="centerY" secondItem="UUZ-nI-xH1" secondAttribute="centerY" id="ZHB-JZ-YKE"/>
+                    <constraint firstItem="7nv-2U-xMp" firstAttribute="leading" secondItem="4Dk-kD-sMy" secondAttribute="trailing" constant="10" id="i0n-S1-xnn"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.xib
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -38,7 +36,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X8O-Gg-slz">
-                    <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                     <items>
                         <navigationItem id="5CU-MZ-p1K">
                             <nil key="title"/>
@@ -98,7 +96,7 @@
                     </items>
                 </navigationBar>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="4gR-Bn-quP">
-                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                    <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="5" minimumInteritemSpacing="5" id="VDa-Pp-VBq">
                         <size key="itemSize" width="50" height="50"/>
@@ -112,10 +110,10 @@
                     </connections>
                 </collectionView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HPm-Vc-F86">
-                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                    <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="gi6-Sw-3Zf">
-                            <rect key="frame" x="137.5" y="239" width="100" height="125.5"/>
+                            <rect key="frame" x="137.5" y="249" width="100" height="125.5"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YDZ-o1-AXT">
                                     <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
@@ -140,20 +138,20 @@
                     </constraints>
                 </view>
                 <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="AEv-G6-dRI">
-                    <rect key="frame" x="177" y="323" width="20" height="20"/>
+                    <rect key="frame" x="177.5" y="323.5" width="20" height="20"/>
                 </activityIndicatorView>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jcn-hC-Umh" customClass="TLAlbumPopView" customModule="TLPhotoPicker" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                    <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GKD-We-AdT">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.29999999999999999" colorSpace="calibratedRGB"/>
                         </view>
                         <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eL2-gJ-b87">
                             <rect key="frame" x="1" y="17" width="373" height="130"/>
                             <subviews>
                                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" style="plain" separatorStyle="default" rowHeight="75" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="grw-Nk-Sxr">
-                                    <rect key="frame" x="10" y="0.0" width="363" height="130"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="373" height="130"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </tableView>
                             </subviews>
@@ -162,12 +160,12 @@
                                 <constraint firstItem="grw-Nk-Sxr" firstAttribute="top" secondItem="eL2-gJ-b87" secondAttribute="top" id="DAx-an-6Qt"/>
                                 <constraint firstAttribute="height" constant="130" id="cet-yf-3jU"/>
                                 <constraint firstAttribute="trailing" secondItem="grw-Nk-Sxr" secondAttribute="trailing" id="nM5-IG-MPJ"/>
-                                <constraint firstItem="grw-Nk-Sxr" firstAttribute="leading" secondItem="eL2-gJ-b87" secondAttribute="leading" constant="10" id="o4b-cS-L3T"/>
+                                <constraint firstItem="grw-Nk-Sxr" firstAttribute="leading" secondItem="eL2-gJ-b87" secondAttribute="leading" id="o4b-cS-L3T"/>
                                 <constraint firstAttribute="bottom" secondItem="grw-Nk-Sxr" secondAttribute="bottom" id="sPK-1G-qLo"/>
                             </constraints>
                         </view>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5zn-je-qLx">
-                            <rect key="frame" x="180" y="10" width="14" height="7"/>
+                            <rect key="frame" x="180.5" y="10" width="14" height="7"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="7" id="eZN-nB-EHu"/>
                                 <constraint firstAttribute="width" constant="14" id="hWo-ji-iBX"/>


### PR DESCRIPTION
Since #219 has been an issue for a while, I'm gonna fix it myself :)

A few notes:

- I removed the 10px margin on the tableview cell and applied it to the thumbnail. I think it makes more sense this way.
- The `systemBackground` color is adaptive. There's no need to check for dark mode like what you did I think. Just use it and it will be white/black as appropriate.
- **The navbar is still broken: if you open the photo picker and then switch to the opposite appearance, the navbar background doesn't adapt to the change.** I actually didn't realize it before, but when I'm validating my change using your sample project I saw this bug. It's most likely you aren't using an adaptive color for the navbar background, but I couldn't find where you set it. Can you fix this?

Thank you!