### PR TITLE
Add long press preview for images

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
+++ b/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
@@ -52,6 +52,8 @@ open class TLPhotoCollectionViewCell: UICollectionViewCell {
         }
     }
     
+    open internal(set) var asset: PHAsset?
+    
     @objc open var isCameraCell = false
     
     open var duration: TimeInterval? {

--- a/TLPhotoPicker/TLPhotoPicker.xcodeproj/project.pbxproj
+++ b/TLPhotoPicker/TLPhotoPicker.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		189E996E21F8BA7F00A754E4 /* TLPhotopickerDataSourcesProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189E996C21F8BA7F00A754E4 /* TLPhotopickerDataSourcesProtocol.swift */; };
 		189E996F21F8BA7F00A754E4 /* TLAssetCollection+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189E996D21F8BA7F00A754E4 /* TLAssetCollection+Extension.swift */; };
 		18A3E62D224FADAD009A9567 /* SynchronizedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A3E62C224FADAD009A9567 /* SynchronizedDictionary.swift */; };
+		B8E49AB223CC5FE900626917 /* TLAssetPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8E49AB123CC5FE900626917 /* TLAssetPreviewViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		189E996C21F8BA7F00A754E4 /* TLPhotopickerDataSourcesProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TLPhotopickerDataSourcesProtocol.swift; path = Classes/TLPhotopickerDataSourcesProtocol.swift; sourceTree = SOURCE_ROOT; };
 		189E996D21F8BA7F00A754E4 /* TLAssetCollection+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "TLAssetCollection+Extension.swift"; path = "Classes/TLAssetCollection+Extension.swift"; sourceTree = SOURCE_ROOT; };
 		18A3E62C224FADAD009A9567 /* SynchronizedDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SynchronizedDictionary.swift; path = Classes/SynchronizedDictionary.swift; sourceTree = SOURCE_ROOT; };
+		B8E49AB123CC5FE900626917 /* TLAssetPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLAssetPreviewViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +78,7 @@
 			children = (
 				18465DBA206E8AFD0015A715 /* TLPhotoPickerController.bundle */,
 				18A3E62C224FADAD009A9567 /* SynchronizedDictionary.swift */,
+				B8E49AB123CC5FE900626917 /* TLAssetPreviewViewController.swift */,
 				18465DAC206E8AEB0015A715 /* TLAlbumPopView.swift */,
 				18465DAD206E8AEB0015A715 /* TLAssetsCollection.swift */,
 				189E996D21F8BA7F00A754E4 /* TLAssetCollection+Extension.swift */,
@@ -180,6 +183,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				18465DB0206E8AEB0015A715 /* TLPhotosPickerViewController.swift in Sources */,
+				B8E49AB223CC5FE900626917 /* TLAssetPreviewViewController.swift in Sources */,
 				189E996E21F8BA7F00A754E4 /* TLPhotopickerDataSourcesProtocol.swift in Sources */,
 				18465DB6206E8AEB0015A715 /* TLAlbumPopView.swift in Sources */,
 				189E996F21F8BA7F00A754E4 /* TLAssetCollection+Extension.swift in Sources */,

--- a/TLPhotoPicker/TLPhotoPicker/TLAssetPreviewViewController.swift
+++ b/TLPhotoPicker/TLPhotoPicker/TLAssetPreviewViewController.swift
@@ -1,0 +1,204 @@
+import UIKit
+import Photos
+import PhotosUI
+
+open class TLAssetPreviewViewController: UIViewController {
+    
+    fileprivate var player: AVPlayer?
+    fileprivate var playerLayer: AVPlayerLayer?
+    
+    fileprivate let imageView: UIImageView = {
+        let view = UIImageView()
+        view.clipsToBounds = false
+        view.contentMode = .scaleAspectFill
+        return view
+    }()
+    
+    fileprivate let livePhotoView = PHLivePhotoView()
+
+    open var asset: PHAsset? {
+        didSet {
+            guard let asset = self.asset else {
+                livePhotoView.livePhoto = nil
+                imageView.image = nil
+                return
+            }
+
+            updatePreferredContentSize(for: asset, isPortrait: UIApplication.shared.orientation?.isPortrait == true)
+            
+            if asset.mediaType == .image {
+                previewImage(from: asset)
+            } else {
+                previewVideo(from: asset)
+            }
+        }
+    }
+    
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        setupViews()
+    }
+    
+    override open func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        playerLayer?.frame = imageView.bounds
+    }
+    
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        if let asset = self.asset {
+            updatePreferredContentSize(for: asset, isPortrait: size.height > size.width)
+        }
+    }
+
+    deinit {
+        player?.pause()
+    }
+}
+
+private extension TLAssetPreviewViewController {
+    func setupViews() {
+        view.backgroundColor = .previewBackground
+        view.addAligned(imageView)
+        view.addAligned(livePhotoView)
+    }
+    
+    func fetchImage(for asset: PHAsset, canHandleDegraded: Bool = true, completion: @escaping ((UIImage?) -> Void)) {
+        let options = PHImageRequestOptions()
+        options.isNetworkAccessAllowed = true
+        options.deliveryMode = .opportunistic
+        PHCachingImageManager.default().requestImage(
+            for: asset,
+            targetSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
+            contentMode: .aspectFit,
+            options: options,
+            resultHandler: { (image, info) in
+                if !canHandleDegraded {
+                    if let isDegraded = info?[PHImageResultIsDegradedKey] as? Bool, isDegraded {
+                        return
+                    }
+                }
+                completion(image)
+        })
+    }
+    
+    func updatePreferredContentSize(for asset: PHAsset, isPortrait: Bool) {
+        guard asset.pixelWidth != 0 && asset.pixelHeight != 0 else { return }
+        
+        let contentScale: CGFloat = 1
+        let assetWidth = CGFloat(asset.pixelWidth)
+        let assetHeight = CGFloat(asset.pixelHeight)
+        let assetRatio = assetHeight / assetWidth
+        let screenWidth = isPortrait ? UIScreen.main.bounds.width : UIScreen.main.bounds.height
+        let screenHeight = isPortrait ? UIScreen.main.bounds.height : UIScreen.main.bounds.width
+        let screenRatio = screenHeight / screenWidth
+        
+        if assetRatio > screenRatio {
+            let scale = screenHeight / assetHeight
+            preferredContentSize = CGSize(width: assetWidth * scale * contentScale, height: assetHeight * scale * contentScale)
+        } else {
+            let scale = screenWidth / assetWidth
+            preferredContentSize = CGSize(width: assetWidth * scale * contentScale, height: assetHeight * scale * contentScale)
+        }
+    }
+    
+    func previewVideo(from asset: PHAsset) {
+        livePhotoView.isHidden = true
+        PHCachingImageManager.default().requestAVAsset(
+            forVideo: asset,
+            options: nil,
+            resultHandler: { (avAsset, audio, info) in
+                DispatchQueue.main.async { [weak self] in
+                    self?.imageView.isHidden = false
+                    
+                    if let avAsset = avAsset {
+                        let playerItem = AVPlayerItem(asset: avAsset)
+                        let player = AVPlayer(playerItem: playerItem)
+                        let playerLayer = AVPlayerLayer(player: player)
+                        playerLayer.videoGravity = AVLayerVideoGravity.resizeAspect
+                        playerLayer.masksToBounds = true
+                        playerLayer.frame = self?.imageView.bounds ?? .zero
+                        
+                        self?.imageView.layer.addSublayer(playerLayer)
+                        self?.playerLayer = playerLayer
+                        self?.player = player
+                        
+                        player.play()
+                    } else {
+                        self?.previewPhoto(from: asset)
+                    }
+                }
+        })
+    }
+
+    func previewImage(from asset: PHAsset) {
+        imageView.isHidden = true
+        livePhotoView.isHidden = false
+        
+        if asset.mediaSubtypes == .photoLive {
+            previewLivePhoto(from: asset)
+        } else {
+            previewPhoto(from: asset)
+        }
+    }
+    
+    func previewLivePhoto(from asset: PHAsset) {
+        
+        let options = PHLivePhotoRequestOptions()
+        options.isNetworkAccessAllowed = true
+        options.deliveryMode = .opportunistic
+
+        PHCachingImageManager.default().requestLivePhoto(
+            for: asset,
+            targetSize: CGSize(width: asset.pixelWidth, height: asset.pixelHeight),
+            contentMode: .aspectFill,
+            options: options,
+            resultHandler: { [weak self] (livePhoto, info) in
+                if let livePhoto = livePhoto, info?[PHImageErrorKey] == nil {
+                    self?.livePhotoView.livePhoto = livePhoto
+                    self?.livePhotoView.startPlayback(with: .full)
+                } else {
+                    self?.previewPhoto(from: asset)
+                }
+        })
+    }
+    
+    func previewPhoto(from asset: PHAsset) {
+        imageView.isHidden = false
+        fetchImage(for: asset, canHandleDegraded: false, completion: { self.imageView.image = $0 })
+    }
+}
+
+private extension UIColor {
+    static var previewBackground: UIColor {
+        if #available(iOS 13.0, *) {
+            return .systemBackground
+        } else {
+            return .white
+        }
+    }
+}
+
+private extension UIView {
+    func addAligned(_ view: UIView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(view)
+        
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: trailingAnchor),
+            view.topAnchor.constraint(equalTo: topAnchor),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}
+
+private extension UIApplication {
+    var orientation: UIInterfaceOrientation? {
+        if #available(iOS 13.0, *) {
+            return windows.first(where: { $0.isKeyWindow })?.windowScene?.interfaceOrientation
+        } else {
+            return statusBarOrientation
+        }
+    }
+}


### PR DESCRIPTION
### Purpose

Adds long press preview to images.

### Details

This PR adds support for long press previews of photos/videos. 

On iOS versions <13.0 it only shows a preview of the selected asset, while on iOS 13+ it also adds a contextual menu with the option to select/deselect the previewed photo. 

The previews support static photos, live photos and videos. 

## Changes

In order to achieve this, a new read-only property was added to `TLPhotoCollectionViewCell`: 
`open internal(set) var asset: PHAsset?` as well as 2 delegate callbacks to `TLPhotosPickerViewController`. 

`public func previewingContext(_ previewingContext: UIViewControllerPreviewing, viewControllerForLocation location: CGPoint) -> UIViewController?` is used for iOS <13 devices and only shows a preview of the photo on a force touch. 

`public func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration?` is used for iOS 13+ devices and shows the context menu to select/deselect the photo. 

### Screenshots

<p float="left">
  <img src="https://user-images.githubusercontent.com/7189912/72243027-1094df00-35eb-11ea-97c5-508cd20499f8.PNG" width="281" height="609">
  <img src="https://user-images.githubusercontent.com/7189912/72243030-1094df00-35eb-11ea-8119-32737b2172a6.gif" width="281" height="609">
</p>




