### PR TITLE
Hide orderBgView and orderLabel when singleSelectedMode is true

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
+++ b/TLPhotoPicker/Classes/TLPhotoCollectionViewCell.swift
@@ -49,6 +49,8 @@ open class TLPhotoCollectionViewCell: UICollectionViewCell {
             self.selectedView?.layer.borderColor = self.configure.selectedColor.cgColor
             self.orderBgView?.backgroundColor = self.configure.selectedColor
             self.videoIconImageView?.image = self.configure.videoIcon
+            self.orderBgView?.isHidden = self.configure.singleSelectedMode
+            self.orderLabel?.isHidden = self.configure.singleSelectedMode
         }
     }
     


### PR DESCRIPTION
I think it's more logical to hide the orderBgView and orderLabel while the singleSelectedMode is true.