### PR TITLE
PHPhotoLibraryChangeObserver wrong section for subclasses

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -885,20 +885,20 @@ extension TLPhotosPickerViewController: PHPhotoLibraryChangeObserver {
                         guard let `self` = self else { return }
                         self.focusedCollection?.fetchResult = changes.fetchResultAfterChanges
                         if let removed = changes.removedIndexes, removed.count > 0 {
-                            self.collectionView.deleteItems(at: removed.map { IndexPath(item: $0+addIndex, section:0) })
+                            self.collectionView.deleteItems(at: removed.map { IndexPath(item: $0+addIndex, section:self.collectionView.numberOfSections - 1) })
                         }
                         if let inserted = changes.insertedIndexes, inserted.count > 0 {
-                            self.collectionView.insertItems(at: inserted.map { IndexPath(item: $0+addIndex, section:0) })
+                            self.collectionView.insertItems(at: inserted.map { IndexPath(item: $0+addIndex, section:self.collectionView.numberOfSections - 1) })
                         }
                         changes.enumerateMoves { fromIndex, toIndex in
-                            self.collectionView.moveItem(at: IndexPath(item: fromIndex, section: 0),
-                                                         to: IndexPath(item: toIndex, section: 0))
+                            self.collectionView.moveItem(at: IndexPath(item: fromIndex, section: self.collectionView.numberOfSections - 1),
+                                                         to: IndexPath(item: toIndex, section: self.collectionView.numberOfSections - 1))
                         }
                     }, completion: { [weak self] (completed) in
                         guard let `self` = self else { return }
                         if completed {
                             if let changed = changes.changedIndexes, changed.count > 0 {
-                                self.collectionView.reloadItems(at: changed.map { IndexPath(item: $0+addIndex, section:0) })
+                                self.collectionView.reloadItems(at: changed.map { IndexPath(item: $0+addIndex, section:self.collectionView.numberOfSections - 1) })
                             }
                         }
                     })


### PR DESCRIPTION
subclasses of TLPhotoPicker that have multiple sections will crash when PHPhotoLibraryChangeObserver updates collectionview if section 0 is not the expected photos section.
removed hard-coding section to 0 in 'photoLibraryDidChange'. using last section in collectionView instead.