### PR TITLE
Update PHImageRequestOptions

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotoLibrary.swift
+++ b/TLPhotoPicker/Classes/TLPhotoLibrary.swift
@@ -109,7 +109,7 @@ class TLPhotoLibrary {
         let options = PHImageRequestOptions()
         options.isSynchronous = true
         options.resizeMode = .none
-        options.isNetworkAccessAllowed = false
+        options.isNetworkAccessAllowed = true
         options.version = .current
         var image: UIImage? = nil
         _ = PHCachingImageManager().requestImageData(for: asset, options: options) { (imageData, dataUTI, orientation, info) in


### PR DESCRIPTION
for get full Resolution images in icloud.

if options.isNetworkAccessAllowed is false, i can't get fullResolutionImageData when my images aren't local but icloud.
and also there's all other options.isNetworkAccessAllowed are true.

This fix works for my problem.
