### PR TITLE
Fix iPad Air Crash observed

### DIFF
--- a/Example/TLPhotoPicker.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/TLPhotoPicker.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -649,6 +649,14 @@ extension TLPhotosPickerViewController: UIImagePickerControllerDelegate, UINavig
         picker.mediaTypes = mediaTypes
         picker.allowsEditing = false
         picker.delegate = self
+        
+        // if user is on ipad using split view controller, present picker as popover
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            picker.modalPresentationStyle = .popover
+            picker.popoverPresentationController?.sourceView = view
+            picker.popoverPresentationController?.sourceRect = .zero
+        }
+        
         self.present(picker, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Fixed crash occurring on iPad Air by including an idiom check which changes the alert presentation style if the user is on iPad.

Error occurs when using a split view controller on iPad, because the popover style must be specified in order to tell the alert where it should display.