### PR TITLE
Support for having non-square previews + make `selectCameraCell` open to allow for opening custom camera without needing a custom cell

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -1242,7 +1242,7 @@ extension TLPhotosPickerViewController: UIViewControllerPreviewingDelegate {
 }
 
 extension TLPhotosPickerViewController {
-    func selectCameraCell(_ cell: TLPhotoCollectionViewCell) {
+    public func selectCameraCell(_ cell: TLPhotoCollectionViewCell) {
         if Platform.isSimulator {
             print("not supported by the simulator.")
         } else {

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -81,6 +81,7 @@ public struct TLPhotosPickerConfigure {
     public var minimumInteritemSpacing: CGFloat = 5
     public var singleSelectedMode = false
     public var maxSelectedAssets: Int? = nil
+    public var thumbnailHeightWidthAspectRatio: CGFloat = 1
     public var fetchOption: PHFetchOptions? = nil
     public var fetchCollectionOption: [FetchCollectionType: PHFetchOptions] = [:]
     public var selectedColor = UIColor(red: 88/255, green: 144/255, blue: 255/255, alpha: 1.0)
@@ -407,7 +408,8 @@ extension TLPhotosPickerViewController {
         }
         let count = CGFloat(self.configure.numberOfColumn)
         let width = floor((self.view.frame.size.width - (self.configure.minimumInteritemSpacing * (count-1))) / count)
-        self.thumbnailSize = CGSize(width: width, height: width)
+        let height = self.configure.thumbnailHeightWidthAspectRatio * width
+        self.thumbnailSize = CGSize(width: width, height: height)
         layout.itemSize = self.thumbnailSize
         layout.minimumInteritemSpacing = self.configure.minimumInteritemSpacing
         layout.minimumLineSpacing = self.configure.minimumLineSpacing

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -351,6 +351,19 @@ open class TLPhotosPickerViewController: UIViewController {
         }
     }
     
+    open func selectCameraCell(_ cell: TLPhotoCollectionViewCell) {
+        if Platform.isSimulator {
+            print("not supported by the simulator.")
+        } else {
+            if configure.cameraCellNibSet?.nibName != nil {
+                cell.selectedCell()
+            } else {
+                showCameraIfAuthorized()
+            }
+            logDelegate?.selectedCameraCell(picker: self)
+        }
+    }
+    
     open func maxCheck() -> Bool {
         deselectWhenUsingSingleSelectedMode()
         if let max = self.configure.maxSelectedAssets, max <= self.selectedAssets.count {
@@ -1242,18 +1255,6 @@ extension TLPhotosPickerViewController: UIViewControllerPreviewingDelegate {
 }
 
 extension TLPhotosPickerViewController {
-    public func selectCameraCell(_ cell: TLPhotoCollectionViewCell) {
-        if Platform.isSimulator {
-            print("not supported by the simulator.")
-        } else {
-            if configure.cameraCellNibSet?.nibName != nil {
-                cell.selectedCell()
-            } else {
-                showCameraIfAuthorized()
-            }
-            logDelegate?.selectedCameraCell(picker: self)
-        }
-    }
     
     func toggleSelection(for cell: TLPhotoCollectionViewCell, at indexPath: IndexPath) {
         guard let collection = focusedCollection, var asset = collection.getTLAsset(at: indexPath), let phAsset = asset.phAsset else { return }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -81,7 +81,7 @@ public struct TLPhotosPickerConfigure {
     public var minimumInteritemSpacing: CGFloat = 5
     public var singleSelectedMode = false
     public var maxSelectedAssets: Int? = nil
-    public var thumbnailHeightWidthAspectRatio: CGFloat = 1
+    public var cellHeightWidthAspectRatio: CGFloat = 1
     public var fetchOption: PHFetchOptions? = nil
     public var fetchCollectionOption: [FetchCollectionType: PHFetchOptions] = [:]
     public var selectedColor = UIColor(red: 88/255, green: 144/255, blue: 255/255, alpha: 1.0)
@@ -408,7 +408,7 @@ extension TLPhotosPickerViewController {
         }
         let count = CGFloat(self.configure.numberOfColumn)
         let width = floor((self.view.frame.size.width - (self.configure.minimumInteritemSpacing * (count-1))) / count)
-        let height = self.configure.thumbnailHeightWidthAspectRatio * width
+        let height = self.configure.cellHeightWidthAspectRatio * width
         self.thumbnailSize = CGSize(width: width, height: height)
         layout.itemSize = self.thumbnailSize
         layout.minimumInteritemSpacing = self.configure.minimumInteritemSpacing


### PR DESCRIPTION
This is two parts, the first (`selectCameraCell` -> open) was done so I could open my own cameraView without needing a custom camera cell.  I guess I can get rid of this if you really want, but it's not breaking.

The second part I was pretty amazed to find lacking - all preview cells in the picker are always squares.

Simple fix (great code, easy to do) - add a cellHWAspectRatio to the config, then use that to compute height.