### PR TITLE
Reset thumbnailSize to allow updating the item size when change the device orientation

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -331,6 +331,11 @@ open class TLPhotosPickerViewController: UIViewController {
         }
     }
     
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+            super.viewWillTransition(to: size, with: coordinator)
+            self.thumbnailSize = CGSize.zero
+    }
+    
     private func findIndexAndReloadCells(phAsset: PHAsset) {
         if
             self.configure.groupByFetch != nil,


### PR DESCRIPTION
Reset `thumbnailSize` when detect changed device orientation so it could be calculated again to fit the new view width