### PR TITLE
Fix for empty state

### DIFF
--- a/TLPhotoPicker/Classes/TLAssetsCollection.swift
+++ b/TLPhotoPicker/Classes/TLAssetsCollection.swift
@@ -358,6 +358,11 @@ public struct TLAssetsCollection {
             return count + (self.useCameraButton ? 1 : 0)
         }
     }
+    var assetCount: Int {
+        get {
+            return self.fetchResult?.count ?? 0
+        }
+    }
     
     init(collection: PHAssetCollection) {
         self.phAssetCollection = collection

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -606,7 +606,7 @@ extension TLPhotosPickerViewController: TLPhotoLibraryDelegate {
     func loadCompleteAllCollection(collections: [TLAssetsCollection]) {
         self.collections = collections
         self.focusFirstCollection()
-        let isEmpty = self.collections.count == 0
+        let isEmpty = !self.collections.contains(where: { $0.count > 0 })
         self.subTitleStackView.isHidden = isEmpty
         self.emptyView.isHidden = !isEmpty
         self.emptyImageView.isHidden = self.emptyImageView.image == nil

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -606,7 +606,7 @@ extension TLPhotosPickerViewController: TLPhotoLibraryDelegate {
     func loadCompleteAllCollection(collections: [TLAssetsCollection]) {
         self.collections = collections
         self.focusFirstCollection()
-        let isEmpty = !self.collections.contains(where: { $0.count > 0 })
+        let isEmpty = !self.collections.contains(where: { $0.assetCount > 0 })
         self.subTitleStackView.isHidden = isEmpty
         self.emptyView.isHidden = !isEmpty
         self.emptyImageView.isHidden = self.emptyImageView.image == nil


### PR DESCRIPTION
This change is needed to properly display the empty image when all albums are empty. Currently the camera button counts as an items and the empty state does not show.