### PR TITLE
Make init for TLPHAsset public.

### DIFF
--- a/TLPhotoPicker/Classes/TLAssetsCollection.swift
+++ b/TLPhotoPicker/Classes/TLAssetsCollection.swift
@@ -321,7 +321,7 @@ public struct TLPHAsset {
         }
     }
     
-    init(asset: PHAsset?) {
+    public init(asset: PHAsset?) {
         self.phAsset = asset
     }
 


### PR DESCRIPTION
Change the `init` for `TLPHAsset` from private to public. This allows for more customizability, such as being able to launch `TLPhotoPicker` with already selected `PHAssets` from another source.