### PR TITLE
Fix "Cannot find 'TARGET_OS_SIMULATOR' in scope" error in Xcode 16.3.

### DIFF
--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -125,7 +125,11 @@ public enum PopupConfigure {
 
 public struct Platform {
     public static var isSimulator: Bool {
-        return ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != nil // Use this line in Xcode 7 or newer
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        return false
+        #endif
     }
 }
 

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -125,7 +125,7 @@ public enum PopupConfigure {
 
 public struct Platform {
     public static var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0 // Use this line in Xcode 7 or newer
+        return ProcessInfo.processInfo.environment["SIMULATOR_DEVICE_NAME"] != nil // Use this line in Xcode 7 or newer
     }
 }
 


### PR DESCRIPTION
![Screenshot 2025-04-01 at 09 32 34](https://github.com/user-attachments/assets/4b081a5a-0ce2-44d9-96d3-116ef9f1df36)
