### PR TITLE
Add didCaptureMediaURL callback to bypass camera roll

### DIFF
--- a/TLPhotoPicker/Classes/TLCameraService.swift
+++ b/TLPhotoPicker/Classes/TLCameraService.swift
@@ -105,6 +105,11 @@ class TLCameraService: NSObject {
         picker.cameraDevice = configure.defaultToFrontFacingCamera ? .front : .rear
         picker.mediaTypes = mediaTypes
         picker.allowsEditing = false
+        if didCaptureMediaURL != nil {
+            if #available(iOS 11.0, *) {
+                picker.imageExportPreset = .compatible
+            }
+        }
         picker.delegate = self
 
         // iPad split view support
@@ -190,13 +195,17 @@ extension TLCameraService: UIImagePickerControllerDelegate, UINavigationControll
             let tempDir = FileManager.default.temporaryDirectory
             if let videoURL = info[.mediaURL] as? URL {
                 let destURL = tempDir.appendingPathComponent(UUID().uuidString + ".mov")
-                try? FileManager.default.copyItem(at: videoURL, to: destURL)
-                bypass(destURL)
-            } else if let image = info[.originalImage] as? UIImage,
-                      let data = image.jpegData(compressionQuality: 0.9) {
-                let destURL = tempDir.appendingPathComponent(UUID().uuidString + ".jpg")
-                try? data.write(to: destURL)
-                bypass(destURL)
+                do {
+                    try FileManager.default.copyItem(at: videoURL, to: destURL)
+                    bypass(destURL)
+                } catch {}
+            } else if let imageURL = info[.imageURL] as? URL {
+                let ext = imageURL.pathExtension.isEmpty ? "jpg" : imageURL.pathExtension
+                let destURL = tempDir.appendingPathComponent(UUID().uuidString + "." + ext)
+                do {
+                    try FileManager.default.copyItem(at: imageURL, to: destURL)
+                    bypass(destURL)
+                } catch {}
             }
             return
         }

--- a/TLPhotoPicker/Classes/TLCameraService.swift
+++ b/TLPhotoPicker/Classes/TLCameraService.swift
@@ -214,5 +214,7 @@ extension TLCameraService: UIImagePickerControllerDelegate, UINavigationControll
                 saveCapturedAsset(videoURL: videoURL)
             }
         }
+
+        picker.dismiss(animated: true, completion: nil)
     }
 }

--- a/TLPhotoPicker/Classes/TLCameraService.swift
+++ b/TLPhotoPicker/Classes/TLCameraService.swift
@@ -21,6 +21,7 @@ class TLCameraService: NSObject {
     // MARK: - Callbacks
     var handleNoCameraPermissions: (() -> Void)?
     var didCaptureAsset: ((TLPHAsset) -> Void)?
+    var didCaptureMediaURL: ((URL) -> Void)?
     weak var logDelegate: TLPhotosPickerLogDelegate?
 
     // MARK: - Configuration
@@ -182,7 +183,24 @@ extension TLCameraService: UIImagePickerControllerDelegate, UINavigationControll
         picker.dismiss(animated: true, completion: nil)
     }
 
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+        picker.dismiss(animated: true, completion: nil)
+
+        if let bypass = didCaptureMediaURL {
+            let tempDir = FileManager.default.temporaryDirectory
+            if let videoURL = info[.mediaURL] as? URL {
+                let destURL = tempDir.appendingPathComponent(UUID().uuidString + ".mov")
+                try? FileManager.default.copyItem(at: videoURL, to: destURL)
+                bypass(destURL)
+            } else if let image = info[.originalImage] as? UIImage,
+                      let data = image.jpegData(compressionQuality: 0.9) {
+                let destURL = tempDir.appendingPathComponent(UUID().uuidString + ".jpg")
+                try? data.write(to: destURL)
+                bypass(destURL)
+            }
+            return
+        }
+
         if let image = info[.originalImage] as? UIImage {
             saveCapturedAsset(image: image)
         } else if let mediaType = info[.mediaType] as? String {
@@ -192,12 +210,9 @@ extension TLCameraService: UIImagePickerControllerDelegate, UINavigationControll
             } else {
                 isMovieType = mediaType == "public.movie"
             }
-
             if isMovieType, let videoURL = info[.mediaURL] as? URL {
                 saveCapturedAsset(videoURL: videoURL)
             }
         }
-
-        picker.dismiss(animated: true, completion: nil)
     }
 }

--- a/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
+++ b/TLPhotoPicker/Classes/TLPhotosPickerViewController.swift
@@ -121,6 +121,10 @@ open class TLPhotosPickerViewController: UIViewController {
     @objc open var handleNoAlbumPermissions: ((TLPhotosPickerViewController) -> Void)? = nil
     @objc open var handleNoCameraPermissions: ((TLPhotosPickerViewController) -> Void)? = nil
     @objc open var dismissCompletion: (() -> Void)? = nil
+    public var didCaptureMediaURL: ((URL) -> Void)? {
+        get { cameraService.didCaptureMediaURL }
+        set { cameraService.didCaptureMediaURL = newValue }
+    }
     private var completionWithPHAssets: (([PHAsset]) -> Void)? = nil
     private var completionWithTLPHAssets: (([TLPHAsset]) -> Void)? = nil
     private var didCancel: (() -> Void)? = nil


### PR DESCRIPTION
When didCaptureMediaURL is set on TLPhotosPickerViewController, captured
photos and videos are written to a temp file and the URL is passed to the
callback instead of being saved to the photo library. Existing behaviour
is unchanged when the callback is not set.
