### PR TITLE
docs: document camera media URL callback

### DIFF
--- a/Documentation/ADVANCED.md
+++ b/Documentation/ADVANCED.md
@@ -99,6 +99,7 @@ class TLPhotosPickerViewController {
     var handleNoAlbumPermissions: ((TLPhotosPickerViewController) -> Void)? = nil
     var handleNoCameraPermissions: ((TLPhotosPickerViewController) -> Void)? = nil
     var dismissCompletion: (() -> Void)? = nil
+    var didCaptureMediaURL: ((URL) -> Void)? = nil
 }
 ```
 
@@ -145,6 +146,16 @@ class ViewController: UIViewController {
     }
 }
 ```
+
+### Bypass Photo Library for Camera Captures
+
+```swift
+picker.didCaptureMediaURL = { url in
+    // Move or copy this temporary file if you need to keep it.
+}
+```
+
+When set, camera captures are returned as temporary file URLs instead of being saved to the Photo Library.
 
 ## Custom Cells
 

--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -315,7 +315,10 @@ public var didExceedMaximumNumberOfSelection: ((TLPhotosPickerViewController) ->
 public var handleNoAlbumPermissions: ((TLPhotosPickerViewController) -> Void)?
 public var handleNoCameraPermissions: ((TLPhotosPickerViewController) -> Void)?
 public var dismissCompletion: (() -> Void)?
+public var didCaptureMediaURL: ((URL) -> Void)?
 ```
+
+When set, camera captures are copied to a temporary file and returned through the callback. Captured media is not saved to the Photo Library, and the callback only runs when the copy succeeds.
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,19 @@ picker.didExceedMaximumNumberOfSelection = { picker in
 }
 ```
 
+### Capture Camera Media URL
+
+```swift
+let picker = TLPhotosPickerViewController()
+picker.didCaptureMediaURL = { url in
+    // Move or copy this temporary file if you need to keep it.
+}
+
+present(picker, animated: true)
+```
+
+When set, camera captures are returned as temporary file URLs instead of being saved to the Photo Library.
+
 ## Delegate Methods
 
 ```swift


### PR DESCRIPTION
## Summary
- Add README usage snippet for `didCaptureMediaURL`
- Add API reference entry for the camera media URL callback
- Add Advanced usage notes covering temporary files, Photo Library bypass, and callback timing

## Verification
- `git diff --check`
- `git diff --cached --check`