### PR TITLE
fix: self-dismiss model for didCaptureMediaURL

### DIFF
--- a/Documentation/ADVANCED.md
+++ b/Documentation/ADVANCED.md
@@ -151,11 +151,14 @@ class ViewController: UIViewController {
 
 ```swift
 picker.didCaptureMediaURL = { url in
-    // Move or copy this temporary file if you need to keep it.
+    // Both the camera picker and TLPhotosPickerViewController are already
+    // dismissed at this point. Just present your next screen.
+    let uploadVC = MyUploadViewController(fileURL: url)
+    presentingViewController.present(uploadVC, animated: true)
 }
 ```
 
-When set, camera captures are returned as temporary file URLs instead of being saved to the Photo Library.
+When set, camera captures are returned as temporary file URLs instead of being saved to the Photo Library. By the time the closure fires, the camera picker and `TLPhotosPickerViewController` have both been fully dismissed — the caller only needs to `present` their next view controller, never `dismiss`.
 
 ## Custom Cells
 

--- a/README.md
+++ b/README.md
@@ -221,13 +221,15 @@ picker.didExceedMaximumNumberOfSelection = { picker in
 ```swift
 let picker = TLPhotosPickerViewController()
 picker.didCaptureMediaURL = { url in
-    // Move or copy this temporary file if you need to keep it.
+    // Both the camera picker and TLPhotosPickerViewController are already
+    // dismissed at this point. Just present your next screen.
+    presentingViewController.present(uploadVC, animated: true)
 }
 
 present(picker, animated: true)
 ```
 
-When set, camera captures are returned as temporary file URLs instead of being saved to the Photo Library.
+When set, camera captures are returned as temporary file URLs instead of being saved to the Photo Library. By the time the closure fires, the camera picker and `TLPhotosPickerViewController` have both been fully dismissed — the caller only needs to `present` their next view controller, never `dismiss`.
 
 ## Delegate Methods
 

--- a/TLPhotoPicker/Classes/TLCameraService.swift
+++ b/TLPhotoPicker/Classes/TLCameraService.swift
@@ -189,26 +189,45 @@ extension TLCameraService: UIImagePickerControllerDelegate, UINavigationControll
     }
 
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
-        picker.dismiss(animated: true, completion: nil)
-
         if let bypass = didCaptureMediaURL {
-            let tempDir = FileManager.default.temporaryDirectory
-            if let videoURL = info[.mediaURL] as? URL {
-                let destURL = tempDir.appendingPathComponent(UUID().uuidString + ".mov")
-                do {
-                    try FileManager.default.copyItem(at: videoURL, to: destURL)
-                    bypass(destURL)
-                } catch {}
-            } else if let imageURL = info[.imageURL] as? URL {
-                let ext = imageURL.pathExtension.isEmpty ? "jpg" : imageURL.pathExtension
-                let destURL = tempDir.appendingPathComponent(UUID().uuidString + "." + ext)
-                do {
-                    try FileManager.default.copyItem(at: imageURL, to: destURL)
-                    bypass(destURL)
-                } catch {}
-            }
+            bypassCapturedMedia(picker: picker, info: info, bypass: bypass)
+        } else {
+            saveCapturedMediaToLibrary(picker: picker, info: info)
+        }
+    }
+
+    private func bypassCapturedMedia(picker: UIImagePickerController,
+                                     info: [UIImagePickerController.InfoKey: Any],
+                                     bypass: @escaping (URL) -> Void) {
+        let tempDir = FileManager.default.temporaryDirectory
+        var capturedURL: URL?
+        if let videoURL = info[.mediaURL] as? URL {
+            let destURL = tempDir.appendingPathComponent(UUID().uuidString + ".mov")
+            do { try FileManager.default.copyItem(at: videoURL, to: destURL); capturedURL = destURL } catch {}
+        } else if let imageURL = info[.imageURL] as? URL {
+            let ext = imageURL.pathExtension.isEmpty ? "jpg" : imageURL.pathExtension
+            let destURL = tempDir.appendingPathComponent(UUID().uuidString + "." + ext)
+            do { try FileManager.default.copyItem(at: imageURL, to: destURL); capturedURL = destURL } catch {}
+        } else if let image = info[.originalImage] as? UIImage,
+                  let data = image.jpegData(compressionQuality: 1.0) {
+            let destURL = tempDir.appendingPathComponent(UUID().uuidString + ".jpg")
+            do { try data.write(to: destURL); capturedURL = destURL } catch {}
+        }
+        guard let capturedURL else {
+            picker.dismiss(animated: true, completion: nil)
             return
-        } else if let image = info[.originalImage] as? UIImage {
+        }
+        picker.dismiss(animated: true) { [weak self] in
+            self?.presentingViewController?.dismiss(animated: true) {
+                bypass(capturedURL)
+            }
+        }
+    }
+
+    private func saveCapturedMediaToLibrary(picker: UIImagePickerController,
+                                            info: [UIImagePickerController.InfoKey: Any]) {
+        picker.dismiss(animated: true, completion: nil)
+        if let image = info[.originalImage] as? UIImage {
             saveCapturedAsset(image: image)
         } else if let mediaType = info[.mediaType] as? String {
             let isMovieType: Bool

--- a/TLPhotoPicker/Classes/TLCameraService.swift
+++ b/TLPhotoPicker/Classes/TLCameraService.swift
@@ -213,12 +213,15 @@ extension TLCameraService: UIImagePickerControllerDelegate, UINavigationControll
             let destURL = tempDir.appendingPathComponent(UUID().uuidString + ".jpg")
             do { try data.write(to: destURL); capturedURL = destURL } catch {}
         }
-        guard let capturedURL else {
+        guard let capturedURL = capturedURL else {
             picker.dismiss(animated: true, completion: nil)
             return
         }
         picker.dismiss(animated: true) { [weak self] in
+            let hostVC = self?.presentingViewController as? TLPhotosPickerViewController
             self?.presentingViewController?.dismiss(animated: true) {
+                hostVC?.delegate?.dismissComplete()
+                hostVC?.dismissCompletion?()
                 bypass(capturedURL)
             }
         }


### PR DESCRIPTION
Restructure the bypass path in TLCameraService so that after a successful camera capture the library dismisses both the camera picker and TLPhotosPickerViewController before invoking the callback. The caller only needs to present their next view controller — no dismiss required.

Changes:
- Split imagePickerController(_:didFinishPickingMediaWithInfo:) into bypassCapturedMedia and saveCapturedMediaToLibrary for clarity
- In the bypass path: dismiss camera picker, then TLPhotosPickerViewController via presentingViewController, then call bypass with the captured URL
- Add info[.originalImage] fallback when info[.imageURL] is unavailable
- Keep TLPhotosPickerViewController.didCaptureMediaURL as a plain passthrough
- Update documentation to show present-only usage pattern